### PR TITLE
Reframe seed-article banners as contribution invitations

### DIFF
--- a/community/knowledge/performance/avoid-growing-globals-in-singleinstance-subscribers.md
+++ b/community/knowledge/performance/avoid-growing-globals-in-singleinstance-subscribers.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Avoid growing globals in SingleInstance subscribers
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/performance/choose-maintainsiftindex-by-read-write-ratio.md
+++ b/community/knowledge/performance/choose-maintainsiftindex-by-read-write-ratio.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Choose MaintainSIFTIndex by read-write ratio
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/performance/load-common-fields-before-branching-on-case.md
+++ b/community/knowledge/performance/load-common-fields-before-branching-on-case.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Load common fields before branching on case
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/performance/load-only-primary-key-fields-for-reference-work.md
+++ b/community/knowledge/performance/load-only-primary-key-fields-for-reference-work.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Load only primary key fields for reference work
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/performance/omit-filter-only-fields-from-setloadfields.md
+++ b/community/knowledge/performance/omit-filter-only-fields-from-setloadfields.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Omit filter-only fields from SetLoadFields
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/performance/order-case-branches-by-frequency.md
+++ b/community/knowledge/performance/order-case-branches-by-frequency.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Order case branches by frequency
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/performance/use-deleteall-for-filtered-bulk-deletion.md
+++ b/community/knowledge/performance/use-deleteall-for-filtered-bulk-deletion.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use DeleteAll for filtered bulk deletion
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/security/compose-permission-sets-with-included-sets.md
+++ b/community/knowledge/security/compose-permission-sets-with-included-sets.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Compose permission sets with IncludedPermissionSets
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/security/do-not-grant-rights-beyond-a-users-entitlement.md
+++ b/community/knowledge/security/do-not-grant-rights-beyond-a-users-entitlement.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Do not grant rights beyond a user's entitlement
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/security/guard-bulk-operations-with-istemporary.md
+++ b/community/knowledge/security/guard-bulk-operations-with-istemporary.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Guard bulk operations with IsTemporary
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/security/prefer-oauth2-over-api-keys-for-external-http-calls.md
+++ b/community/knowledge/security/prefer-oauth2-over-api-keys-for-external-http-calls.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Prefer OAuth2 over API keys for external HTTP calls
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/community/knowledge/security/protect-sensitive-data-in-temporary-tables.md
+++ b/community/knowledge/security/protect-sensitive-data-in-temporary-tables.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Protect sensitive data in temporary tables
 
-> **Seed article.** Ported from BC Code Intelligence to seed the community corpus. Community contributors are invited to expand or refine.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/avoid-commit-inside-loops.md
+++ b/microsoft/knowledge/performance/avoid-commit-inside-loops.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Do not Commit inside loops
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/avoid-user-interaction-in-transactions.md
+++ b/microsoft/knowledge/performance/avoid-user-interaction-in-transactions.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Do not prompt the user inside a write transaction
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/keep-event-subscribers-lightweight.md
+++ b/microsoft/knowledge/performance/keep-event-subscribers-lightweight.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Keep event subscribers lightweight
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/only-fetch-records-you-use.md
+++ b/microsoft/knowledge/performance/only-fetch-records-you-use.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Only fetch records you use
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/prefer-direct-record-over-recordref.md
+++ b/microsoft/knowledge/performance/prefer-direct-record-over-recordref.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Prefer direct record access over RecordRef where possible
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/prefer-get-for-primary-key-lookups.md
+++ b/microsoft/knowledge/performance/prefer-get-for-primary-key-lookups.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Prefer Get for primary-key lookups
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/set-current-key-to-match-filters.md
+++ b/microsoft/knowledge/performance/set-current-key-to-match-filters.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Set the current key to match your filters
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/use-addloadfields-in-report-layouts.md
+++ b/microsoft/knowledge/performance/use-addloadfields-in-report-layouts.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use AddLoadFields in report dataitems
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/use-calcsums-for-flowfield-totals.md
+++ b/microsoft/knowledge/performance/use-calcsums-for-flowfield-totals.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use CalcSums to aggregate filtered sets
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/use-findset-with-next.md
+++ b/microsoft/knowledge/performance/use-findset-with-next.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use FindSet with Next for iteration
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/use-insert-false-when-skipping-triggers.md
+++ b/microsoft/knowledge/performance/use-insert-false-when-skipping-triggers.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Choose Insert, Modify, and Delete parameters deliberately
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/use-isempty-for-existence-checks.md
+++ b/microsoft/knowledge/performance/use-isempty-for-existence-checks.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use IsEmpty for existence checks
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/use-single-instance-codeunits-for-caching.md
+++ b/microsoft/knowledge/performance/use-single-instance-codeunits-for-caching.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use SingleInstance codeunits for session caching
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/performance/use-temporary-tables-for-intermediate-data.md
+++ b/microsoft/knowledge/performance/use-temporary-tables-for-intermediate-data.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use temporary tables for intermediate data
 
-> **Seed article.** Converted from an existing performance-review prompt to bootstrap the BCQuality performance corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/compose-secrets-with-secretstrsubstno.md
+++ b/microsoft/knowledge/security/compose-secrets-with-secretstrsubstno.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Compose secrets with SecretStrSubstNo
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/do-not-expose-sensitive-data-in-event-publishers.md
+++ b/microsoft/knowledge/security/do-not-expose-sensitive-data-in-event-publishers.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Do not expose sensitive data in event publishers
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/follow-least-privilege-in-permission-sets.md
+++ b/microsoft/knowledge/security/follow-least-privilege-in-permission-sets.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Follow least privilege in permission sets
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/never-hardcode-secrets-in-al.md
+++ b/microsoft/knowledge/security/never-hardcode-secrets-in-al.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Never hardcode secrets in AL
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/prefer-azure-key-vault-for-production-secrets.md
+++ b/microsoft/knowledge/security/prefer-azure-key-vault-for-production-secrets.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Prefer Azure Key Vault for production secrets
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/use-indirect-permissions-for-elevated-access.md
+++ b/microsoft/knowledge/security/use-indirect-permissions-for-elevated-access.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use indirect permissions for elevated access
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/use-inherent-permissions-to-grant-minimal-access.md
+++ b/microsoft/knowledge/security/use-inherent-permissions-to-grant-minimal-access.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use InherentPermissions to grant minimal access
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/use-isolated-storage-for-module-and-company-secrets.md
+++ b/microsoft/knowledge/security/use-isolated-storage-for-module-and-company-secrets.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use IsolatedStorage for module and company secrets
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 

--- a/microsoft/knowledge/security/use-nondebuggable-when-parsing-secrets.md
+++ b/microsoft/knowledge/security/use-nondebuggable-when-parsing-secrets.md
@@ -9,7 +9,7 @@ application-area: [all]
 
 # Use NonDebuggable when parsing secrets
 
-> **Seed article.** Converted from an existing security-review prompt to bootstrap the BCQuality security corpus. Domain stewards should expand, restructure, and refine as needed.
+> Contributions welcome — open a PR to refine or extend this article.
 
 ## Description
 


### PR DESCRIPTION
Final preview-polish pass. The 35 articles still in their seed form previously carried:

> **Seed article.** Converted from an existing *X*-review prompt to bootstrap the BCQuality *X* corpus. Domain stewards should expand, restructure, and refine as needed.

To a first-time community visitor that reads as "TODO left in production" on roughly one in three articles. Replacing all three banner variants (performance-seeded, security-seeded, community-ported) with a single positive invitation:

> Contributions welcome — open a PR to refine or extend this article.

Content is unchanged; only the leading quote block differs. Articles that had their banner fully stripped in the earlier triage pass (the showcase-grade ten) are unaffected.

## Test plan

- [x] Validator passes with 0 errors / 0 warnings
- [ ] Spot-check a couple of articles render cleanly on GitHub