### PR TITLE
Improve PR-review parity: suggestion blocks, missing KB articles, privacy cross-ref

### DIFF
--- a/microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md
+++ b/microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md
@@ -17,7 +17,14 @@ application-area: [all]
 
 Keep the telemetry message a static, non-personal string ("Customer record processed", "Error processing uploaded file"). When structured context is genuinely needed, attach it through custom dimensions, where individual values can be reviewed and classified at the dimension level rather than baked into a free-text message.
 
+If a pseudonymous identifier (record `No.`, primary key value) genuinely belongs in the diagnostic, prefer attaching it through a custom dimension and set the call's `DataClassification` to match the data actually shipped — `EndUserPseudonymousIdentifiers` for pseudonymous IDs, `CustomerContent` for content-bearing telemetry. Changing the `DataClassification` alone does **not** make embedding a customer name into the message string acceptable; the data still ships in the message, and downstream consumers still see the literal string.
+
 See sample: `no-pii-in-telemetry-message-string.good.al`.
+
+## Related
+
+- `session-logmessage-requires-dataclassification.md` — every `Session.LogMessage` call must specify `DataClassification`; choose the value to match the actual data shipped, not the value that makes the entry retained the longest.
+- `featuretelemetry-customdimensions-no-pii.md` — custom dimensions are the right surface for structured context, but they have their own PII rules.
 
 ## Anti Pattern
 

--- a/microsoft/knowledge/style/labels-declared-at-object-scope.bad.al
+++ b/microsoft/knowledge/style/labels-declared-at-object-scope.bad.al
@@ -1,0 +1,11 @@
+codeunit 50262 "Sample Label Scope Bad"
+{
+    procedure LookupCustomer(CustomerNo: Code[20])
+    var
+        Customer: Record Customer;
+        GreetingMsg: Label 'Hello %1', Comment = '%1 = Customer Name';
+    begin
+        if Customer.Get(CustomerNo) then
+            Message(GreetingMsg, Customer.Name);
+    end;
+}

--- a/microsoft/knowledge/style/labels-declared-at-object-scope.good.al
+++ b/microsoft/knowledge/style/labels-declared-at-object-scope.good.al
@@ -1,0 +1,13 @@
+codeunit 50263 "Sample Label Scope Good"
+{
+    var
+        GreetingMsg: Label 'Hello %1', Comment = '%1 = Customer Name';
+
+    procedure LookupCustomer(CustomerNo: Code[20])
+    var
+        Customer: Record Customer;
+    begin
+        if Customer.Get(CustomerNo) then
+            Message(GreetingMsg, Customer.Name);
+    end;
+}

--- a/microsoft/knowledge/style/labels-declared-at-object-scope.md
+++ b/microsoft/knowledge/style/labels-declared-at-object-scope.md
@@ -1,0 +1,30 @@
+---
+bc-version: [all]
+domain: style
+keywords: [label, scope, procedure, translation, localization, xliff]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# Declare Labels at object scope, not inside procedure `var` blocks
+
+## Description
+
+`Label` is the AL declaration that participates in the translation pipeline: the build extracts every Label declared in an object into the `.xlf` file shipped to translators, and the runtime substitutes the localized value when the object is loaded. Translation tooling discovers Labels by walking the object's top-level declarations.
+
+Labels declared inside a procedure-local `var` block are still **compiled** as Label values, but their participation in localization is fragile: depending on the BC version, the build pipeline, and the translation toolchain in use, procedure-local Labels may be missed during XLIFF extraction, may be re-emitted with auto-generated keys that change between builds, or may not be addressable by reviewers triaging translations. The reliable, supported pattern is to declare every Label in the object's top-level `var` block.
+
+The same rule applies to all object types that own behavior: codeunits, pages, tables, reports, queries, and their extensions. For shared messages used by multiple objects, declare the Label in the most appropriate owning object and reference it — do not duplicate the literal across procedure-scoped declarations in several places.
+
+## Best Practice
+
+Move every `Label` to the object's top-level `var` block. Use the appropriate suffix (`Msg`, `Err`, `Qst`, `Lbl`, `Tok`, `Txt`) on the variable name so reviewers and the translation team can see at a glance what role the string plays. Pair non-translatable strings (URLs, JSON/XML fragments, integration tokens) with `Locked = true`, as covered by `label-locked-for-non-translatable.md`.
+
+See sample: `labels-declared-at-object-scope.good.al`.
+
+## Anti Pattern
+
+Declaring `Label` inside a procedure-local `var` block — `procedure Lookup() var GreetingMsg: Label 'Hello %1';` — couples the translatable string to one procedure, hides it from object-level review, and depends on a translation pipeline behavior that is not part of the AL language contract.
+
+See sample: `labels-declared-at-object-scope.bad.al`.

--- a/microsoft/knowledge/style/telemetry-event-id-stable-unique.bad.al
+++ b/microsoft/knowledge/style/telemetry-event-id-stable-unique.bad.al
@@ -1,0 +1,13 @@
+codeunit 50260 "Sample Telemetry Id Bad"
+{
+    procedure LogCustomerProcessed(var Customer: Record Customer)
+    begin
+        Session.LogMessage(
+            '0000',
+            'Customer record processed',
+            Verbosity::Normal,
+            DataClassification::SystemMetadata,
+            TelemetryScope::All,
+            'Category', 'QualitySamples');
+    end;
+}

--- a/microsoft/knowledge/style/telemetry-event-id-stable-unique.good.al
+++ b/microsoft/knowledge/style/telemetry-event-id-stable-unique.good.al
@@ -1,0 +1,13 @@
+codeunit 50261 "Sample Telemetry Id Good"
+{
+    procedure LogCustomerProcessed(var Customer: Record Customer)
+    begin
+        Session.LogMessage(
+            'QS0001',
+            'Customer record processed',
+            Verbosity::Normal,
+            DataClassification::SystemMetadata,
+            TelemetryScope::All,
+            'Category', 'QualitySamples');
+    end;
+}

--- a/microsoft/knowledge/style/telemetry-event-id-stable-unique.md
+++ b/microsoft/knowledge/style/telemetry-event-id-stable-unique.md
@@ -1,0 +1,32 @@
+---
+bc-version: [all]
+domain: style
+keywords: [telemetry, logmessage, event-id, sessionlogmessage, observability]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# Telemetry event IDs must be stable, unique, and non-placeholder
+
+## Description
+
+The first parameter of `Session.LogMessage` is the **event ID**. Telemetry consumers — Application Insights queries, KQL dashboards, alert rules, support runbooks — pivot on this ID to filter and aggregate events. The contract works only when the ID is:
+
+- **Stable** across releases: the same logical event keeps the same ID, so existing queries continue to match it.
+- **Unique** within the extension's telemetry catalogue: two different events MUST NOT share an ID, or downstream consumers cannot distinguish them.
+- **Non-placeholder**: literal IDs like `'0000'`, `'1234'`, `'TODO'`, or `'XX0000'` are placeholders that collide with other placeholder-using extensions, are unsearchable, and indicate the catalogue entry was never registered.
+
+The convention used by Microsoft first-party AL code is a short prefix identifying the publisher or feature followed by a numeric suffix — for example `'AL0001'`, `'CUST0042'`, `'SHPFY-0007'`. The exact format is up to the extension; the requirements are stability, uniqueness, and that the chosen ID is registered in whatever catalogue or wiki the extension's telemetry consumers reference.
+
+## Best Practice
+
+Assign each `Session.LogMessage` call a real, registered event ID drawn from the extension's catalogue. Treat the ID as part of the public contract of the event — renaming it is a breaking change for consumers. Keep IDs short, deterministic, and free of personal or environment-specific tokens.
+
+See sample: `telemetry-event-id-stable-unique.good.al`.
+
+## Anti Pattern
+
+Calling `Session.LogMessage('0000', ...)` (or `'1234'`, `'TODO'`, an empty string, a GUID generated at runtime, or any other placeholder) leaves the event unsearchable and indistinguishable from every other event using the same placeholder. The catalogue entry never gets created because the developer "will fix it later", and the placeholder ships.
+
+See sample: `telemetry-event-id-stable-unique.bad.al`.

--- a/microsoft/skills/review/al-code-review.md
+++ b/microsoft/skills/review/al-code-review.md
@@ -85,8 +85,15 @@ For every candidate the agent identifies in this pass:
    - `id` is a skill-defined slug prefixed with `agent:` (for example, `agent:missing-error-handling-on-http-call`).
    - `confidence` capped at `medium`.
    - `message` is non-empty and self-contained, describing both the issue and a concrete recommendation. A consumer rendering the finding has no knowledge-file footer to fall back on.
+   - `suggested-code` SHOULD be set when the fix is small and mechanical (e.g. removing a few unreachable lines, replacing a `Count() > 0` test with `not IsEmpty()`, declaring a missing `Label`). Omit it when the appropriate fix depends on context the agent cannot determine.
 
 Leaf sub-skills MUST NOT emit agent findings: their scope is bounded by the knowledge subset they evaluate. The self-review pass is a super-skill responsibility.
+
+### Suggested-code guidance
+
+For both knowledge-backed findings rolled up from sub-skills and agent findings emitted in the self-review pass, populate `findings[].suggested-code` whenever a concrete code replacement is unambiguous from the diff context. The payload MUST be a literal replacement for the source lines covered by `location` (typically a single line, or the line range in `location.range`) — no diff markers, fences, or commentary. Examples of good candidates: deleting dead code after `exit`, replacing `Count() > 0` with `not IsEmpty()`, moving an inline `Label` declaration to a codeunit-level `var` block, fixing whitespace or keyword casing. Skip `suggested-code` when the fix requires choosing between multiple defensible alternatives or when the surrounding context the agent cannot see could change the answer.
+
+Sub-skills MAY also emit `suggested-code` when their knowledge file unambiguously implies the replacement (the `.good.al` and `.bad.al` companion examples are useful here). The super-skill copies the field through unchanged.
 
 ### Summary and rollup
 

--- a/skills/do.md
+++ b/skills/do.md
@@ -94,7 +94,8 @@ Every action skill emits a single JSON document that conforms to this schema:
         { "path": "string", "sha": "string" }
       ],
       "confidence": "high | medium | low",
-      "from-sub-skill": "string"
+      "from-sub-skill": "string",
+      "suggested-code": "string"
     }
   ],
   "suppressed": [
@@ -167,6 +168,8 @@ The first reference is the **primary** reference: the knowledge file the finding
 **`findings[].confidence`** — the skill's confidence that the finding is a true positive, given the evidence it evaluated. Not applicability confidence, not severity confidence. Values: `high`, `medium`, `low`.
 
 **`findings[].from-sub-skill`** — optional. Set only by super-skills. The `skill.id` of the sub-skill that produced the finding, or the literal string `"agent"` for an agent finding the super-skill produced from its own reasoning. Absent on findings produced directly by a leaf skill.
+
+**`findings[].suggested-code`** — optional. A concrete code-replacement payload for the lines indicated by `location`. When present, the string MUST be a literal replacement for the source lines covered by `location.line` (or `location.range` if set) — i.e., what the file would contain after the fix, with no surrounding diff markers, fences, or commentary. Consumers MAY render it as a one-click suggestion in the delivery surface (for example, a GitHub ```` ```suggestion ```` block). Emit `suggested-code` only when the fix is small, mechanical, and unambiguous; omit it when the appropriate fix depends on context the skill cannot determine. The `suggested-code` payload supplements `message`; it does not replace the explanation in `message`.
 
 **`suppressed`** — MUST list every knowledge file that was discarded due to layer precedence or consumer configuration, whenever that file would otherwise have contributed to the worklist. Each entry contains:
 


### PR DESCRIPTION
Closes parity gaps identified by comparing two PR-review agents against the same code sample:
- `microsoft/BCAppsBCQuality` PR [#24](https://github.com/microsoft/BCAppsBCQuality/pull/24) (BCQuality-backed agent)
- `microsoft/BCAppsCampAIRHack` PR [#160](https://github.com/microsoft/BCAppsCampAIRHack/pull/160) (embedded-knowledge agent)

## Changes

### Contract — `skills/do.md`
Adds an optional `findings[].suggested-code` field. Spec'd as a literal replacement for the source lines covered by `location` — no diff markers, no fences, no commentary. Consumers MAY render it as a one-click suggestion (e.g. GitHub `​`​`​`suggestion`​`​`​` block). Emit only when the fix is small, mechanical, and unambiguous.

### Skill instructions — `microsoft/skills/review/al-code-review.md`
- Tells the agent self-review pass to populate `suggested-code` for mechanical fixes (dead code removal, `Count() > 0` → `not IsEmpty()`, moving an inline `Label` to object scope, casing/whitespace).
- Tells sub-skills they MAY emit `suggested-code` when the `.good.al` companion implies the fix.

### New knowledge — `microsoft/knowledge/style/`
- `telemetry-event-id-stable-unique.{md,good.al,bad.al}` — telemetry event IDs must be stable, unique, and non-placeholder (`'0000'`, `'TODO'`, runtime GUIDs are anti-patterns).
- `labels-declared-at-object-scope.{md,good.al,bad.al}` — `Label` declarations belong in the object's top-level `var` block, not in procedure-local `var` blocks, for reliable XLIFF extraction.

### Privacy clarification — `microsoft/knowledge/privacy/no-pii-in-telemetry-message-string.md`
Adds an explicit note that changing `DataClassification` alone does **not** make embedding a customer name into the message string acceptable — the literal data still ships. Links to the two adjacent privacy articles for the full picture.

## Companion change

BCAppsBCQuality's review orchestrator (`tools/Code Review/scripts/Invoke-CopilotPRReview.ps1`) is updated in a separate PR to read `suggested-code` from the JSON, render it as a GitHub suggestion block, deduplicate the headline against the first sentence of the issue body, and soften the agent-finding disclaimer.
