### PR TITLE
Add community UI knowledge article for default descending sort on historical pages

### DIFF
--- a/community/knowledge/ui/default-descending-sort-on-historical-pages.bad.al
+++ b/community/knowledge/ui/default-descending-sort-on-historical-pages.bad.al
@@ -1,0 +1,29 @@
+page 50100 "Integration Log Entries"
+{
+    PageType = List;
+    SourceTable = "Integration Log Entry";
+    ApplicationArea = All;
+    UsageCategory = History;
+    Caption = 'Integration Log Entries';
+
+    // No descending default sort: the page opens oldest-first.
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(General)
+            {
+                field("Entry No."; Rec."Entry No.")
+                {
+                }
+                field(Status; Rec.Status)
+                {
+                }
+                field(Message; Rec.Message)
+                {
+                }
+            }
+        }
+    }
+}

--- a/community/knowledge/ui/default-descending-sort-on-historical-pages.good.al
+++ b/community/knowledge/ui/default-descending-sort-on-historical-pages.good.al
@@ -1,0 +1,30 @@
+page 50100 "Integration Log Entries"
+{
+    PageType = List;
+    SourceTable = "Integration Log Entry";
+    ApplicationArea = All;
+    UsageCategory = History;
+    Caption = 'Integration Log Entries';
+
+    // Historical pages should open with the newest records first.
+    SourceTableView = order(descending);
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(General)
+            {
+                field("Entry No."; Rec."Entry No.")
+                {
+                }
+                field(Status; Rec.Status)
+                {
+                }
+                field(Message; Rec.Message)
+                {
+                }
+            }
+        }
+    }
+}

--- a/community/knowledge/ui/default-descending-sort-on-historical-pages.md
+++ b/community/knowledge/ui/default-descending-sort-on-historical-pages.md
@@ -1,0 +1,23 @@
+---
+bc-version: [all]
+domain: ui
+keywords: [historical-table, list-page, descending-sort, log-entry, ledger-entry, archive]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# Default descending sort on historical pages
+
+## Description
+Historical list pages should default to showing the newest records first. On pages such as log entries, ledger entries, archives, and other history lists, an oldest-first default order does not align with the primary use of the page, which is typically to review recent activity.
+
+## Best Practice
+Set descending sort as the default on list pages whose primary purpose is to present historical records. This is the expected default for entry, log, archive, and posted-history pages unless there is a specific requirement to begin with the oldest record.
+
+See sample: `default-descending-sort-on-historical-pages.good.al`.
+
+## Anti Pattern
+Using an oldest-first default order on a historical list page where users are primarily interested in recent activity. Typical signs include history, log, or entry pages that regularly need to be re-sorted to descending during normal use.
+
+See sample: `default-descending-sort-on-historical-pages.bad.al`.


### PR DESCRIPTION
## Summary

Add one new community UI knowledge article for default descending sort on historical pages, plus matching good/bad AL samples.

This covers a common page design issue: historical list pages are usually opened to review recent activity, so an oldest-first default order is often the wrong starting point.

- `default-descending-sort-on-historical-pages` — historical list pages should show the newest records first by default unless there is a specific requirement to start from the oldest record.

All files follow the BCQuality format:
- v1 frontmatter
- `Description` / `Best Practice` / `Anti Pattern`
- sibling `.good.al` / `.bad.al` samples

## Files added

- `community/knowledge/ui/default-descending-sort-on-historical-pages.md`
- `community/knowledge/ui/default-descending-sort-on-historical-pages.good.al`
- `community/knowledge/ui/default-descending-sort-on-historical-pages.bad.al`