### PR TITLE
do.md: require strict RFC 8259 JSON with escaped quotes/newlines

### DIFF
--- a/skills/do.md
+++ b/skills/do.md
@@ -117,6 +117,12 @@ Every action skill emits a single JSON document that conforms to this schema:
 }
 ```
 
+### JSON validity
+
+The emitted document MUST be strict, valid JSON per [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259). Inside every string value, all double quotes MUST be escaped as `\"` and all line breaks as `\n`; other control characters MUST use their JSON escapes. This is not optional polish — it is the difference between a parseable report and one a consumer silently drops.
+
+AL source is the common failure case. Quoted identifiers (for example `Rec."No."`) and multi-line snippets routinely appear in `message`, `suggested-code`, and `suggested-code-omission-reason`, and each embedded quote or newline MUST be escaped when placed in a string value. A `suggested-code` payload that spans several lines is a single JSON string with `\n` separators, not a literal multi-line block. Emit the document as one JSON value with no trailing commentary, and do not rely on the consumer to repair unescaped output.
+
 ### Field semantics
 
 **`outcome`** (required) —


### PR DESCRIPTION
## Problem

The DO output contract specifies the JSON schema and field semantics but never states that the emitted document must be valid, escaped JSON. Action skills emit AL source into `message`, `suggested-code`, and `suggested-code-omission-reason`. AL quoted identifiers (e.g. `Rec."No."`) and multi-line snippets routinely contain double quotes and newlines; when those are not escaped, a consuming orchestrator's `JSON.parse`/`ConvertFrom-Json` fails and silently drops the entire findings-report.

## Change

Add a short **JSON validity** subsection to `skills/do.md`, immediately after the output schema, making the RFC 8259 requirement explicit: escape `"` as `\"` and line breaks as `\n` inside every string value, and emit multi-line `suggested-code` as a single `\n`-separated JSON string rather than a literal multi-line block.

## Why a contract change

Consumers can add parse-side repair heuristics, but unescaped quotes/newlines inside string values are not reliably recoverable. The durable fix is to require valid output at the source, where the contract every action skill follows is defined.


[AB#638957](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638957)