### PR TITLE
Add domain expert reviewers to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,13 @@
 # GitHub Actions and CI
 /.github/ @jeschulz
 
+# Domain experts — required reviewers for coding rules
+/microsoft/knowledge/performance/ @BardurKnudsen @pchriste-microsoft-com
+/microsoft/knowledge/privacy/     @haoranpb @pchriste-microsoft-com
+/microsoft/knowledge/security/    @darjoo @WaelAbuSeada @Aleyenda @pchriste-microsoft-com
+/microsoft/knowledge/style/       @nikolakukrika @jesperschulz @pchriste-microsoft-com
+/microsoft/knowledge/testing/     @nikolakukrika @ventselartur @pchriste-microsoft-com
+/microsoft/knowledge/upgrade/     @nikolakukrika @pchriste-microsoft-com
+
 # Community content — open to broader review
 # /community/ reviewers are added as the contributor base grows


### PR DESCRIPTION
Adds required domain expert reviewers for the coding rules under `microsoft/knowledge/<domain>/`. These entries follow the general `/microsoft/` rule so CODEOWNERS' last-match-wins precedence routes each domain to its experts.

| Domain | Reviewers |
| --- | --- |
| Performance | @BardurKnudsen, @pchriste-microsoft-com |
| Privacy | @haoranpb, @pchriste-microsoft-com |
| Security | @darjoo, @WaelAbuSeada, @Aleyenda, @pchriste-microsoft-com |
| Style | @nikolakukrika, @jesperschulz, @pchriste-microsoft-com |
| Testing | @nikolakukrika, @ventselartur, @pchriste-microsoft-com |
| Upgrade | @nikolakukrika, @pchriste-microsoft-com |

Note: to make these *required*, branch protection must have "Require review from Code Owners" enabled.