### PR TITLE
Fix CODEOWNERS: correct @jeschulz -> @jesperschulz on base rules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # Microsoft-endorsed content and skills require maintainer review
-/microsoft/ @jeschulz
-/skills/ @jeschulz
+/microsoft/ @jesperschulz
+/skills/ @jesperschulz
 
 # GitHub Actions and CI
-/.github/ @jeschulz
+/.github/ @jesperschulz
 
 # Domain experts — required reviewers for coding rules
 /microsoft/knowledge/events/      @AleksandricMarko @pchriste-microsoft-com


### PR DESCRIPTION
## Problem

GitHub's CODEOWNERS validator (`gh api repos/microsoft/BCQuality/codeowners/errors`) flagged the handle `@jeschulz` as an **Unknown owner**. This is a typo — the repo owner's correct, valid handle is `@jesperschulz`, which is already used and accepted on the style line (`/microsoft/knowledge/style/`).

As a result of the typo, the base rules `/microsoft/`, `/skills/`, and `/.github/` had no valid code owner.

## Change

Replaced `@jeschulz` with `@jesperschulz` on the three base-rule lines only:

- `/microsoft/ @jeschulz` → `/microsoft/ @jesperschulz`
- `/skills/ @jeschulz` → `/skills/ @jesperschulz`
- `/.github/ @jeschulz` → `/.github/ @jesperschulz`

After the change there are 0 occurrences of `@jeschulz` and 4 of `@jesperschulz`. No other lines were touched.

## Notes

- The domain-expert reviewer lines were left untouched.
- The domain-expert reviewers still require **write access** to the repo to be auto-requested; that is handled separately by the owner.

## Validation

- `python .github/scripts/validate_frontmatter.py --root .` → 0 errors / 0 warnings
- `pwsh .github/scripts/Test-KnowledgeIndex.ps1 -Root .` → PASSED, 191 articles

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>