### PR TITLE
style-review: fix example finding id to match references[0].path

### DIFF
--- a/microsoft/skills/review/al-style-review.md
+++ b/microsoft/skills/review/al-style-review.md
@@ -89,7 +89,7 @@ Output conforms to the DO output contract. A populated example:
   },
   "findings": [
     {
-      "id": "microsoft/knowledge/style/apply-approved-label-suffixes.md",
+      "id": "microsoft/knowledge/style/label-suffix-approved-list.md",
       "severity": "info",
       "message": "A Label named Text000 has no approved suffix (Msg/Err/Qst/Tok/Lbl/Txt). Per the referenced CodeCop AA0074 guidance, every Label and TextConst carries a suffix indicating its consuming call.",
       "location": {


### PR DESCRIPTION
## Problem

The `al-style-review` worked example emits a finding whose `id` points to a non-existent knowledge file:

```json
"id": "microsoft/knowledge/style/apply-approved-label-suffixes.md",
...
"references": [
  { "path": "microsoft/knowledge/style/label-suffix-approved-list.md" }
]
```

`apply-approved-label-suffixes.md` does not exist; the real file is `label-suffix-approved-list.md`. The DO output contract states that for citation-based findings, `id` MUST equal `references[0].path`. The example violated its own contract.

## Change

One line: align the example `id` to the existing file (`label-suffix-approved-list.md`), matching `references[0].path`.

## Context

Follow-up to #95. The fix was authored against #95 but landed after that PR was already merged, so it needs its own PR.

## Risk

Documentation/example only. No behavioural change.
