### PR TITLE
Document the skill-vs-knowledge boundary so BC facts land in knowledge files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Poor fit: "Use HTTPS instead of HTTP." "Don't hardcode secrets." "Keep transacti
 
 The practical consequence: when a code-review agent flags something it shouldn't have, or misses something it should have caught, the remedy is a new knowledge file. When it already behaves correctly on a topic, no file is needed.
 
+A file that *prevents* a false positive — documenting why a pattern is legitimate so the agent stops flagging it — is as valid as one that catches a defect: negative clarifications are first-class knowledge files. What never belongs is a BC fact hard-coded into a skill. Skills are finders and appliers; knowledge files are what the agent knows. See [`skills/do.md`](skills/do.md) and [`skills/write.md`](skills/write.md).
+
 ## What's in this repo
 
 BCQuality contains **knowledge** and **skills**. It does not contain agents. Agents that consume BCQuality ship with [AL-Go](https://github.com/microsoft/AL-Go) and other orchestrators.
@@ -147,6 +149,7 @@ Contributions are welcome. Before submitting a PR:
 1. Read the knowledge file format above — frontmatter and sections are validated by CI.
 2. Keep files atomic: one concern per file, under 100 lines.
 3. Target your contribution to the right layer — most community contributions go in `/community/knowledge/`.
+4. Adding a BC fact — or stopping the agent from flagging a false positive — is a knowledge file, not a skill edit. If a PR changes *what* a review skill flags, the change almost certainly belongs in a knowledge file. See [`skills/write.md`](skills/write.md).
 
 CI runs validation on every PR. If your knowledge file has schema violations, missing sections, code blocks, or exceeds 100 lines, the check will fail with a clear error message.
 

--- a/skills/do.md
+++ b/skills/do.md
@@ -21,6 +21,19 @@ An action skill is a single markdown file with YAML frontmatter. It lives inside
 
 Action skills do not live at the repo root. The files in `/skills/` — the three meta-skill contracts (READ, DO, WRITE) and the entry-point skill (`entry.md`, `kind: entry-point`) — are the only skills that sit outside a layer. The entry-point skill structurally follows this same four-step pattern but produces a dispatch record rather than a findings-report; see `skills/entry.md` for its contract.
 
+## Skills hold mechanics; knowledge files hold BC facts
+
+An action skill is a *finder and applier*: its prose says how to discover candidate knowledge (Source), filter it (Relevance), narrow it to the task (Worklist), and shape output (Action). Every Business-Central-specific behavioural claim a skill acts on — what a property defaults to, what a trigger does, why a given shape is or is not a defect — belongs in a knowledge file the skill cites, not in the skill prose.
+
+This includes **negative knowledge**. A false-positive guard — "pattern X is not a defect, because BC does Y" — is as much a knowledge file as a positive best practice. When an eval shows the agent over-reporting a pattern, the fix is a knowledge file documenting why the pattern is legitimate, so the skill can cite it and any leaf can reuse it — not a hard-coded exclusion buried in one skill. See `skills/write.md` (*Is this a knowledge file?*).
+
+Two rules follow for skill authors:
+
+- **Do not add a BC fact to a skill.** If you are editing a skill to change *what it flags* — adding an exclusion, encoding a platform default, teaching it that some pattern is fine — you are holding a knowledge file, not a skill edit. Author the knowledge file and let Worklist route to it.
+- **Do not restate an article's fact inline.** A Worklist cue may name the article to load and the diff shape that selects it; it must not re-assert the article's reasoning, which then drifts from the source. Cite, don't copy.
+
+The meta-skills themselves (`read.md`, `do.md`, `write.md`) are domain-agnostic templates and carry no BC-specific rule.
+
 ## Frontmatter schema
 
 ```yaml

--- a/skills/write.md
+++ b/skills/write.md
@@ -9,6 +9,25 @@ title: New Knowledge — how to author a knowledge file
 
 Anyone — human or agent — adding a knowledge file to BCQuality follows this guide. READ is the format specification; WRITE is the authoring guide. This file does not restate the schema; consult READ for field-by-field semantics.
 
+## Is this a knowledge file?
+
+Before authoring anything, confirm a knowledge file is the right artifact. BCQuality separates *mechanics* from *facts*:
+
+- **Skills** (`*/skills/**`) hold only finder/applier mechanics — how to discover, filter, worklist, and emit findings. See `skills/do.md`.
+- **Knowledge files** (`*/knowledge/**`) hold every Business-Central-specific fact a skill acts on.
+
+A new BC fact is therefore a knowledge file, never a skill edit. In particular, if you arrived here because a review agent flagged something it should not have (a false positive) or missed something it should have caught, the remedy is a knowledge file — apply the admission test in the [README](../README.md#what-belongs-here): *would a capable LLM get this wrong without the file?* If you find yourself editing a skill to stop it flagging something, stop and write a knowledge file instead.
+
+### Negative knowledge is first-class
+
+A knowledge file does not have to recommend an action. A **negative clarification** — "pattern X is *not* a defect, because BC behaves as Y" — is a first-class knowledge file, authored exactly like a positive rule:
+
+- **Description** states the BC behaviour that makes the pattern legitimate.
+- **Best Practice** tells the reviewer or agent what *not* to flag, and why.
+- **Anti Pattern** describes the false-positive report itself — the mistaken finding to suppress.
+
+For example, `microsoft/knowledge/error-handling/page-boolean-triggers-default-to-true.md` records that the Boolean page record triggers return `true` by default, so a "missing `exit(true)`" report is not a real defect. It reads as ordinary knowledge; its anti-pattern is the incorrect review comment, not the code.
+
 ## Before you start
 
 Read `skills/read.md` first. A file that does not conform to READ will be rejected. WRITE assumes READ is already understood.


### PR DESCRIPTION
## Problem

Reviewing #112 exposed a documentation gap, not an agent-capability gap. That PR started by encoding false-positive guards in `do.md`, then moved them into leaf skills, and only after two review rounds landed them as knowledge articles. The root cause: **nothing tells an author where a new BC fact (or a false-positive guard) belongs.** The decision material existed but was split across `README`/`do.md`/`write.md`, lived in an overview file rather than at the point of action, and was framed only as *positive* best practices — so "this is *not* a defect" knowledge had no obvious home.

## Changes

**`skills/do.md` — new section "Skills hold mechanics; knowledge files hold BC facts."** States the boundary at the point a skill author works: a skill is a finder/applier; every BC behavioural claim it acts on must be a *cited* knowledge file. Names **negative knowledge** (false-positive guards) as first-class, and adds two rules — don't add a BC fact to a skill, and don't restate an article's fact inline (the duplication/drift smell).

**`skills/write.md` — new "Is this a knowledge file?" decision gate** at the top, so the first question an author answers is whether a knowledge file is even the right artifact. Adds a **"Negative knowledge is first-class"** subsection mapping a false-positive guard onto Description / Best Practice / Anti Pattern, with a worked example (`page-boolean-triggers-default-to-true.md`).

**`README.md`** — notes that false-positive-preventing files are as valid as defect-catching ones, and adds a reviewer heuristic to Contributing: *if a PR changes what a review skill flags, the change almost certainly belongs in a knowledge file.*

## Notes

- Prose-only additions; the repo's own `validate_frontmatter.py` passes clean (0 errors, 0 warnings).
- Meta-skill contract semantics (schema, four-step pattern, output contract) are unchanged, so `version` stays `1`. If maintainers consider the explicit boundary rule a contract change, bump it.
- Related but **out of scope**: the existing review leaves still restate a handful of article facts inline as detection cues (e.g. `al-events-review`, `al-interfaces-review`, `al-style-review`). Unlike #112's six patterns, each already has a backing article, so that is a de-duplication cleanup, not missing knowledge — the new "don't restate inline" rule covers it going forward.