### PR TITLE
tooltip: PR review flags genuinely-missing tooltips instead of deferring to AA0218

### DIFF
--- a/microsoft/knowledge/style/tooltip-required-on-page-fields.md
+++ b/microsoft/knowledge/style/tooltip-required-on-page-fields.md
@@ -15,9 +15,11 @@ CodeCop AA0218 requires a non-empty `ToolTip` property on every field control on
 
 Acceptable exceptions: table fields inside `Upgrade`, `Migration`, `HybridBC14`, `HybridSL`, and `HybridGP` codeunits and tables are allowed to omit the tooltip — those types are not surfaced to users.
 
+AA0218 is a compiler analyzer, but its severity is configured per app in the ruleset and is frequently downgraded to `info`/`None` or disabled entirely. PR review therefore cannot assume the compiler will surface the gap: it is the last line of defence for a missing tooltip and should flag it independently. The one case review must *not* flag is a bound field that inherits a `ToolTip` from its source table field — see `bound-page-field-inherits-source-field-tooltip`.
+
 ## Best Practice
 
-Every field control on a regular page carries `ToolTip = 'Specifies …';` (or a clear alternative phrasing). Compose the text in the form "what this value shows" rather than "what the user does with it".
+Every field control on a regular page carries `ToolTip = 'Specifies …';` (or a clear alternative phrasing). Compose the text in the form "what this value shows" rather than "what the user does with it". In review, raise a `medium`-severity finding for a field that has neither an inline nor an inherited tooltip, independently of whether AA0218 is active in the app's ruleset.
 
 See sample: `tooltip-required-on-page-fields.good.al`.
 

--- a/microsoft/knowledge/ui/bound-page-field-inherits-source-field-tooltip.md
+++ b/microsoft/knowledge/ui/bound-page-field-inherits-source-field-tooltip.md
@@ -13,12 +13,12 @@ application-area: [all]
 
 A page field bound to a table field inherits the source field's `ToolTip` at runtime: the control shows the table field's `ToolTip` even when the page control declares none of its own. A page field without an inline `ToolTip` is therefore not, by itself, a missing-tooltip defect — the text may be supplied by the bound source field.
 
-The genuinely-missing case — a bound field whose source table field also carries no `ToolTip`, or an unbound control that needs one — is already reported by the compiler analyzer AA0218, which BCQuality calibrates to `info`. That analyzer, not an agent finding, owns the missing-tooltip signal.
+The genuinely-missing case is different: a bound field whose source table field *also* carries no `ToolTip`, or an unbound control, has no text to inherit and is a real accessibility gap. The compiler analyzer AA0218 detects this mechanically, but its severity is set by each app's ruleset and is routinely downgraded or disabled — so it cannot be relied on as the only net. PR review is the last line of defence and should raise this case independently.
 
 ## Best Practice
 
-Do not raise a missing-`ToolTip` finding for a page field that has a source-table binding; assume the source field supplies the tooltip. Reserve tooltip findings for the cases the dedicated tooltip rules define, and let analyzer AA0218 carry the mechanically-detectable missing-tooltip case at its calibrated severity.
+Do not raise a missing-`ToolTip` finding for a bound page field whose source table field supplies a `ToolTip`; assume the control inherits it. Do raise a `medium`-severity finding when the field has no inline `ToolTip` **and** no inherited one — that is, a bound field whose source field is also tooltip-less, or an unbound control — rather than assuming AA0218 will catch it downstream.
 
 ## Anti Pattern
 
-Flagging every page field that has no inline `ToolTip` property as an accessibility violation, ignoring that a bound field inherits its source field's tooltip and that AA0218 already covers the truly-missing case.
+Two opposite failures: (1) flagging every page field that has no inline `ToolTip` as a violation, ignoring that a bound field inherits its source field's tooltip; and (2) staying silent on a field that has neither an inline nor an inherited tooltip on the assumption that the compiler's AA0218 will report it — a ruleset that downgrades or disables AA0218 then lets a genuine gap ship unflagged.


### PR DESCRIPTION
## Problem

The v1.4 tooltip policy defers **every** missing-tooltip case to the compiler analyzer AA0218, treating the analyzer as the sole owner of the missing-tooltip signal. But AA0218's severity is configured per app in the ruleset and is routinely downgraded to `info`/`None` or disabled outright. When that happens, a genuinely-missing tooltip ships with **nothing** flagging it — the PR review, which is the last line of defence, stays silent by design.

## Change

Re-scope the policy so PR review independently flags the genuinely-missing case, while keeping the original false-positive guard intact.

| Case | Before (v1.4) | After |
|---|---|---|
| Bound field + source field **has** ToolTip | not flagged | **not flagged** (inheritance — unchanged) |
| Bound field + source field **also lacks** ToolTip | not flagged (deferred to AA0218) | **flagged, medium** |
| Unbound control, no ToolTip | not flagged (deferred to AA0218) | **flagged, medium** |

Two files:
- `ui/bound-page-field-inherits-source-field-tooltip.md` — keeps the inheritance FP guard; changes the genuinely-missing case from "AA0218 owns it, agent stays silent" to "agent raises a medium finding". Anti-Pattern now names both opposite failures (over-flagging inherited fields **and** staying silent on a real gap).
- `style/tooltip-required-on-page-fields.md` — adds that AA0218 severity is per-app configurable and often downgraded, so review must flag independently; cross-references the inheritance article for the one case not to flag.

## Rationale

PR review is the last line of defence. Assuming the compiler ruleset always keeps AA0218 active is unsafe: many teams tune their rulesets and would silently lose the accessibility signal. Raising it in review adds a safety net without re-introducing the original inheritance false positive (issue seen on BCApps #9315).
