### PR TITLE
knowledge: 3 FP-suppression guards from BC apps negative feedback

### DIFF
--- a/microsoft/knowledge/error-handling/unchecked-get-throws-when-record-not-found.md
+++ b/microsoft/knowledge/error-handling/unchecked-get-throws-when-record-not-found.md
@@ -1,0 +1,26 @@
+---
+bc-version: [all]
+domain: error-handling
+keywords: [get, record-not-found, runtime-error, return-value, boolean-method, false-positive]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# An unchecked Record.Get raises an error when the record is missing; it is not silently ignored
+
+## Description
+
+`Record.Get` returns a Boolean, but its behavior when no record is found depends on whether the return value is consumed. When the return value is used — inside `if Rec.Get(...) then`, or assigned to a variable — a missing record yields `false` and execution continues. When `Rec.Get(...)` is called as a bare statement and the return value is not used, the platform raises a runtime "record not found" error if the record does not exist. A bare `Rec.Get(Key)` therefore acts as an assertion that the record exists: it does not swallow or silently ignore a missing record. This mirrors other AL find methods, where an unconsumed return value lets the platform enforce the not-found error.
+
+## Best Practice
+
+Do not claim that a `Record.Get` whose return value is unused silently ignores a missing record or hides an error. Treat a bare `Rec.Get(...)` statement as an intentional existence assertion that already throws when the record is absent. Recommend an explicit existence check only when the surrounding logic must continue gracefully rather than error out.
+
+## Anti Pattern
+
+Flagging a bare `Rec.Get(Key)` statement as a defect because "the return value is ignored, so a missing record is swallowed", or recommending it be wrapped in `if Rec.Get(...) then ... else Error(...)` to "handle the not-found case" — the unchecked call already raises an error when the record is missing.
+
+## See also
+
+- `ignored-tryfunction-return-disables-try-semantics.md` — a different case where ignoring a Boolean return value changes behavior.

--- a/microsoft/knowledge/performance/onaftergetcurrrecord-is-not-per-row.md
+++ b/microsoft/knowledge/performance/onaftergetcurrrecord-is-not-per-row.md
@@ -1,0 +1,26 @@
+---
+bc-version: [all]
+domain: performance
+keywords: [onaftergetcurrrecord, onaftergetrecord, calcfields, n-plus-one, page-lifecycle, false-positive]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# Database work in OnAfterGetCurrRecord is not a per-row or N+1 cost
+
+## Description
+
+`OnAfterGetCurrRecord` fires only when the current/active record changes — typically once when the page opens and once each time the user selects a different row — not once for every row rendered in a list. Database work placed there, such as `CalcFields`, `Get`, or a lookup, therefore runs a bounded number of times driven by user navigation, not multiplied by the number of visible rows. This is unlike `OnAfterGetRecord`, which fires once per row as the page loads records and can create a genuine N+1 pattern. Reviewers sometimes see `CalcFields` or a database call inside a page trigger and assume it runs for every row; the trigger name determines whether that assumption holds.
+
+## Best Practice
+
+Before flagging `CalcFields`, `Get`, or a similar database call in a page trigger as a per-row or N+1 problem, confirm the trigger is `OnAfterGetRecord`, which runs per row. Do not flag the same work in `OnAfterGetCurrRecord`: that trigger runs on current-record change, not for every displayed row.
+
+## Anti Pattern
+
+Reporting `CalcFields` or another database call inside `OnAfterGetCurrRecord` as an N+1 or per-row performance defect, or recommending it be moved out "to avoid running once per row". The trigger does not run per row.
+
+## See also
+
+- `calcfields-in-both-getrecord-triggers-is-not-redundant.md` — the lifecycle distinction between the two triggers.

--- a/microsoft/knowledge/upgrade/obsoletereason-need-not-restate-removal-version.md
+++ b/microsoft/knowledge/upgrade/obsoletereason-need-not-restate-removal-version.md
@@ -1,0 +1,26 @@
+---
+bc-version: [all]
+domain: upgrade
+keywords: [obsolete-reason, obsolete-tag, deprecation, version, metadata, false-positive]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# ObsoleteReason need not restate the removal version; ObsoleteTag carries it
+
+## Description
+
+An obsoleted object, field, key, enum, or enum value carries both `ObsoleteReason` and `ObsoleteTag`, and the two properties have different jobs. `ObsoleteReason` is free text that explains why the element is obsolete and what replaces it. `ObsoleteTag` identifies when it became obsolete — typically the version, release, or work item that introduced the obsoletion. The version traceability lives in `ObsoleteTag`; there is no requirement that `ObsoleteReason` also name the removal version or repeat what the tag already records. A reason that omits a version number is complete as long as it explains the deprecation and points to a replacement, provided `ObsoleteTag` pins the version.
+
+## Best Practice
+
+When `ObsoleteTag` already carries the version or tracking reference, do not flag `ObsoleteReason` for not mentioning a version or removal release. Judge `ObsoleteReason` on whether it explains the deprecation and names a replacement, and judge version traceability on `ObsoleteTag` instead.
+
+## Anti Pattern
+
+Flagging an `ObsoleteReason` as vague, incomplete, or missing a version reference solely because it does not restate the removal version, when `ObsoleteTag` already records that version. Requiring the reason to duplicate the tag's version is not a real convention.
+
+## See also
+
+- `obsoletion-requires-reason-and-tag.md` — both properties are required; the reason names the replacement and the tag identifies when the element became obsolete.


### PR DESCRIPTION
## Summary

Adds three false-positive suppression knowledge articles derived from thumbs-down feedback on BC apps PR reviews. Each encodes an AL fact that the review agent got wrong, so the corresponding finding is suppressed going forward.

## Articles

| File | Concern | Source |
| --- | --- | --- |
| `microsoft/knowledge/upgrade/obsoletereason-need-not-restate-removal-version.md` | `ObsoleteTag` carries the removal version; do not flag `ObsoleteReason` for omitting it. | PR 8290 (6 findings, maintainer thumbs-down) |
| `microsoft/knowledge/error-handling/unchecked-get-throws-when-record-not-found.md` | A bare `Rec.Get()` raises a runtime error when the record is missing; it is not silently ignored. | PR 8584 (dev-confirmed) |
| `microsoft/knowledge/performance/onaftergetcurrrecord-is-not-per-row.md` | `OnAfterGetCurrRecord` fires on current-record change, not per visible row; `CalcFields` there is not N+1. | PR 8617 (dev-confirmed) |

## Notes

- Each is a negative-clarification article (no sibling `.al`), matching the existing FP-suppression style (`unreleased-schema-change-needs-no-upgrade-path.md`, `page-boolean-triggers-default-to-true.md`).
- All 6 frontmatter fields present; `false-positive` keyword on each.
- `Build-KnowledgeIndex.ps1` parses all three (index count 245 → 248). `knowledge-index.json` is regenerated and not committed.
- Aligns with (does not contradict) `obsoletion-requires-reason-and-tag.md` and `calcfields-in-both-getrecord-triggers-is-not-redundant.md`, cross-referenced in `## See also`.
