### PR TITLE
Move plugin.json to plugin root; declare skills for CLI/marketplace compliance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,10 @@
       "name": "bcquality",
       "source": "./",
       "description": "Business Central AL quality knowledge base and review skills, packaged as an installable plugin. Ships the entire BCQuality tree (skills, knowledge, tools) so the Entry routing protocol runs against the installed clone.",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "skills": [
+        "./skills/bcquality-al-review/"
+      ]
     }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -5,5 +5,17 @@
   "author": {
     "name": "microsoft/BCQuality",
     "url": "https://github.com/microsoft/BCQuality"
-  }
+  },
+  "repository": "https://github.com/microsoft/BCQuality",
+  "license": "MIT",
+  "keywords": [
+    "bc",
+    "al",
+    "business-central",
+    "code-review",
+    "quality"
+  ],
+  "skills": [
+    "./skills/bcquality-al-review/"
+  ]
 }


### PR DESCRIPTION
## Problem

The plugin manifest layout did not match the [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference), which states the manifest must be a `plugin.json` file **at the root of the plugin directory**. BCQuality shipped `plugin.json` only under `.claude-plugin/`.

To be precise about what was and was not broken:
- `plugin.json` **does** exist (added when BCQuality was packaged as an installable plugin) — so "there is no plugin.json" is not accurate.
- The absence of a `skills` array is **not** a defect: the reference documents `skills/` as the default location, and BCQuality's skill already lives at `skills/bcquality-al-review/`. That is why `copilot --plugin-dir <clone>` already auto-discovered and registered the skill.
- The one real deviation from the documented format was the **location of `plugin.json`** (`.claude-plugin/` instead of the plugin root). `--plugin-dir` tolerates the `.claude-plugin/` location, but it is non-canonical and can be rejected on the stricter marketplace / `copilot plugin install owner/repo` path.

## Change

Mirror the proven `microsoft/BC-ALAgents` `al-review` plugin layout:
- Move `plugin.json` to the repository (plugin) root.
- Add an explicit `skills: ["./skills/bcquality-al-review/"]` array to both `plugin.json` and `marketplace.json`. This pins the single real skill and avoids any ambiguity with the loose meta `.md` files (`entry.md`, `do.md`, `read.md`, `write.md`) that also sit under `skills/`.
- Add `repository` / `license` / `keywords` metadata for parity and completeness.

`source: "./"` is kept intentionally: the bridge skill's Entry protocol needs the full BCQuality tree (knowledge, tools, layer skills), so the whole repository is the plugin.

## Verification

`copilot --plugin-dir <clone>` was run before and after the change:
- `copilot ... plugin list` lists the `bcquality` plugin in both cases.
- A live session confirms the `bcquality-al-review` skill registers at runtime in both cases (identical to the known-good `al-review` plugin).

No functional change to the already-working `--plugin-dir` consumption path; this brings the manifest into documented compliance and unblocks the marketplace / `plugin install` path.
