### PR TITLE
Fix bridge skill manifest references after #122 root move

### DIFF
--- a/skills/bcquality-al-review/SKILL.md
+++ b/skills/bcquality-al-review/SKILL.md
@@ -24,8 +24,8 @@ Do **not** use this skill to *generate* AL code — it only reviews.
 
 ## Plugin root
 
-Resolve `PLUGIN_ROOT` to the directory that contains this plugin's
-`.claude-plugin/plugin.json`. This skill lives at
+Resolve `PLUGIN_ROOT` to the directory that contains this plugin's root
+`plugin.json`. This skill lives at
 `PLUGIN_ROOT/skills/bcquality-al-review/SKILL.md`, so `PLUGIN_ROOT` is two levels up
 from this file. All paths below are relative to `PLUGIN_ROOT`. If the host exposes a
 plugin-root environment variable, prefer it.
@@ -93,7 +93,8 @@ caller can log the reason.
   `enabled-layers` (`BCQUALITY_ENABLED_LAYERS`) — the denied layers' files still exist on
   disk. Treat `enabled-layers` as a selection filter, not a hard security boundary. A
   future revision could add a genuine deny mechanism (e.g. pruning the installed tree).
-- **Manifest location.** This plugin uses `.claude-plugin/plugin.json`, which both
+- **Manifest location.** This plugin's manifest is the root `plugin.json`, which both
   Claude Code and Copilot CLI accept (verified with Copilot CLI: `plugin install`
-  reports the bridge skill loaded). Copilot CLI also accepts a root `plugin.json`; if a
-  future host only reads the root form, dual-home the manifest.
+  reports the bridge skill loaded). A `.claude-plugin/marketplace.json` alongside it
+  carries the marketplace entry. Claude Code also reads `.claude-plugin/plugin.json`; if
+  a future host only reads that form, dual-home the manifest there.


### PR DESCRIPTION
## What

Doc-only fix to the `bcquality-al-review` bridge skill. PR #122 moved the plugin manifest to the **root** `plugin.json` (and relocated the bridge skill to `skills/bcquality-al-review/`, deleting `.claude-plugin/plugin.json` and the old `plugin/` tree). The bridge `SKILL.md` prose was not updated to match, so it still pointed at the now-deleted `.claude-plugin/plugin.json`.

## Why it matters

- **`## Plugin root`** instructed a host to resolve `PLUGIN_ROOT` by walking up until it finds `.claude-plugin/plugin.json`. That marker no longer exists after #122, so the location-based fallback could never anchor. Now anchors on the root `plugin.json` that #122 created.
- **`## Notes` -> Manifest location** described `.claude-plugin/plugin.json` as the manifest the plugin uses and root `plugin.json` as a hypothetical future form -- the reverse of the post-#122 reality. Now states root `plugin.json` is canonical and `.claude-plugin/marketplace.json` carries the marketplace entry.

## Scope

- Single file: `skills/bcquality-al-review/SKILL.md`, 6 insertions / 5 deletions, prose only.
- No behavior change. Runtime plugin load already works via the host-provided plugin root (`copilot --plugin-dir`), verified end-to-end; this only corrects the fallback/anchor wording and the manifest-location note.
