### PR TITLE
Add FP guards: field relocation to tableextension + event parameter addition (bug 642303)

### DIFF
--- a/microsoft/knowledge/breaking-changes/relocating-a-field-to-a-tableextension-is-not-a-deletion.md
+++ b/microsoft/knowledge/breaking-changes/relocating-a-field-to-a-tableextension-is-not-a-deletion.md
@@ -1,0 +1,18 @@
+---
+bc-version: [all]
+domain: breaking-changes
+keywords: [table-field, tableextension, relocation, field-id, obsoletestate, breaking-change, false-positive]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# Relocating a field to a tableextension in the same app is not a deletion
+
+## Description
+
+Moving a field out of a base-table definition (or a base-app layer modification of one) into a tableextension that `extends` the same table, within the same app and keeping the same field ID and name, is a relocation — not a deletion or a rename. After the move the field still exists on the table: `Rec."Field Name"` and the field ID resolve exactly as before, so dependent extensions that reference the field continue to compile. Nothing in the field's public contract is removed or renamed, so the deprecation lifecycle that protects a genuinely removed field does not apply. LLM reviewers frequently misread the two-sided diff — the field disappearing from the base object and reappearing in the tableextension — as a shipped field being deleted and illegally re-added under the same ID, and demand `ObsoleteState = Pending` staging that this refactor does not need.
+
+## Best Practice
+
+Recognize a field that is removed from a base table (or base-app layer) and re-declared in a tableextension of the same table, with the same field ID and name, as a same-app relocation. Do not flag it as a deleted or renamed shipped field, and do not require `ObsoleteState = Pending`, `ObsoleteReason`, `ObsoleteTag`, or a deprecation window for the move itself. The `obsolete-table-fields-instead-of-deleting-them` and `obsolete-pending-to-removed-staging` rules apply to fields that leave the table's contract entirely, not to fields relocated within the same app under an unchanged ID.

--- a/microsoft/knowledge/events/adding-a-parameter-to-an-event-is-not-a-breaking-change.md
+++ b/microsoft/knowledge/events/adding-a-parameter-to-an-event-is-not-a-breaking-change.md
@@ -1,0 +1,18 @@
+---
+bc-version: [all]
+domain: events
+keywords: [event-parameters, signature, subscriber-binding, backward-compatibility, integration-event, breaking-change, false-positive]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# Adding a parameter to an event is not a breaking change
+
+## Description
+
+Adding a parameter to an existing event publisher does not break existing subscribers. AL binds a subscriber to a publisher by the event name, and the subscriber's parameter list only has to be a subset of the publisher's, matched by name and type. A subscriber that does not declare the new parameter keeps compiling and keeps binding — it simply ignores the addition. This holds for `IntegrationEvent` and `BusinessEvent` publishers, and even more plainly for `local` events. Appending the new parameter at the end keeps the change a clean, reviewable addition (see `add-new-event-parameters-at-the-end`). LLM reviewers often misreport the mere presence of a new event parameter as a "breaking event signature change" that breaks subscribers, which is incorrect.
+
+## Best Practice
+
+Do not flag the addition of a parameter to an event publisher as a breaking or signature-breaking change, and do not claim it breaks existing subscribers. Genuine, separate concerns are covered by their own rules — a parameter inserted in the middle of the list rather than appended (`add-new-event-parameters-at-the-end`), or a parameter that carries no meaningful value — and should be raised on those grounds, not framed as a backward-compatibility break.


### PR DESCRIPTION
## What

Two knowledge false-positive guards that resolve the agent false positives reported in bug 642303, reproduced on BCApps PR #9607 (a deliberate "Test-Code-Reviewer-Comments" PR).

### 1. `breaking-changes/relocating-a-field-to-a-tableextension-is-not-a-deletion.md`
Moving a field out of a base table (or a base-app layer modification of one) into a `tableextension` that extends the same table, within the same app and keeping the same field ID and name, is a relocation — not a deletion or rename. The field still resolves on the table (`Rec."Field Name"` and the ID compile exactly as before), so dependent code is not broken and the obsoletion lifecycle does not apply.

The agent misread the two-sided diff (field removed from the base object, re-declared in the tableextension under the same ID) as a deleted shipped field re-added illegally, and demanded `ObsoleteState = Pending` staging via `obsolete-table-fields-instead-of-deleting-them` / `obsolete-pending-to-removed-staging`.

Scope: **contract axis only.** The guard says the move is not a deletion/rename and needs no obsoletion. It stays deliberately silent on data migration, so genuine data-loss findings on tables with persisted data are not masked.

### 2. `events/adding-a-parameter-to-an-event-is-not-a-breaking-change.md`
Adding a parameter to an event publisher does not break existing subscribers: AL binds subscribers by event name and matches their parameter list as a subset by name/type, so a subscriber that does not declare the new parameter keeps compiling and binding. The addition itself must not be reported as a breaking signature change. Complements the existing `add-new-event-parameters-at-the-end` (which covers the append-position concern).

## Repro (PR #9607)
- Field 7000000 "Bill No." relocated from ES layer table 17 "G/L Entry" to new tableextension "G/L Entry ES" (same ID) -> flagged High "Breaking Changes" (deleted shipped field) + Medium "Upgrade".
- `Test` parameter appended to local event `OnAfterCopyFromDeferralPostBuffer`.

## Notes
- Both files follow the negative-clarification format: `false-positive` in `keywords`, `## Description` + `## Best Practice`, no sibling `.al`, no `## Anti Pattern`.
- `knowledge-index.json` regenerated locally (252 articles, both new slugs present); not committed (gitignored).
- No engine change — false-positive suppression belongs in BCQuality knowledge per the boundary contract.

Refs: [AB#642303](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642303).
