### PR TITLE
Add TransferFields SkipFieldsNotMatchingType guidance

### DIFF
--- a/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.bad.al
+++ b/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.bad.al
@@ -1,0 +1,55 @@
+table 50123 "Transfer Source Bad"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Reference"; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+
+}
+
+table 50124 "Transfer Target Bad"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Reference"; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+
+}
+
+codeunit 50492 "TransferFields Bad"
+{
+    procedure CopyData(Source: Record "Transfer Source Bad"; var Target: Record "Transfer Target Bad")
+    begin
+        Target.TransferFields(Source, true, true);
+    end;
+}

--- a/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.good.al
+++ b/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.good.al
@@ -1,0 +1,56 @@
+table 50121 "Transfer Source"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Reference"; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+
+}
+
+table 50122 "Transfer Target"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Reference"; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+
+}
+
+codeunit 50491 "TransferFields Good"
+{
+    procedure CopyData(Source: Record "Transfer Source"; var Target: Record "Transfer Target")
+    begin
+        Target."Entry No." := Source."Entry No.";
+        Evaluate(Target."Reference", Source."Reference");
+    end;
+}

--- a/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.good.al
+++ b/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.good.al
@@ -49,8 +49,11 @@ table 50122 "Transfer Target"
 codeunit 50491 "TransferFields Good"
 {
     procedure CopyData(Source: Record "Transfer Source"; var Target: Record "Transfer Target")
+    var
+        ConvertedReference: Integer;
     begin
         Target."Entry No." := Source."Entry No.";
-        Evaluate(Target."Reference", Source."Reference");
+        Evaluate(ConvertedReference, Source."Reference");
+        Target.Validate("Reference", ConvertedReference);
     end;
 }

--- a/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.md
+++ b/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.md
@@ -1,0 +1,26 @@
+---
+bc-version: [all]
+domain: data-modeling
+keywords: [transferfields, skipfieldsnotmatchingtype, type-mismatch, field-mapping, data-transfer]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# Do not use SkipFieldsNotMatchingType to hide required TransferFields mismatches
+
+## Description
+
+`Record.TransferFields` copies values between fields with matching field numbers. Without `SkipFieldsNotMatchingType` (or with it `false`), a type mismatch between two fields in the same extension raises a runtime error at the point of transfer. Setting `SkipFieldsNotMatchingType` to `true` removes that error: the field is skipped instead, and the rest of the transfer completes normally. The caller gets no indication that a field was not copied.
+
+## Best Practice
+
+Use `TransferFields(Source)` when matching field definitions are an expected part of the table design. If source and destination fields intentionally have different types, map those fields explicitly and handle the conversion or validation in code. Use `SkipFieldsNotMatchingType = true` only when skipping incompatible fields is an intentional, documented part of the transfer contract.
+
+## Anti Pattern
+
+Using `TransferFields(Source, InitPrimaryKeyFields, true)` as a generic way to make two evolving table schemas transfer without errors, when the destination depends on every required source field being copied. A type change on either table can turn a previously transferred field into a silently skipped one without making the transfer itself fail.
+
+See sample: `transferfields-skip-type-mismatch-can-drop-data.good.al`.
+
+See sample: `transferfields-skip-type-mismatch-can-drop-data.bad.al`.

--- a/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.md
+++ b/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.md
@@ -17,10 +17,10 @@ application-area: [all]
 
 Use `TransferFields(Source)` only when every field the destination requires, including primary key fields, is guaranteed to share a matching field number and type with the source; this form defaults `InitPrimaryKeyFields` to `true`. Fields with no matching field number, and fields whose types differ across extensions, are skipped regardless of `SkipFieldsNotMatchingType` — that parameter only governs same-extension type mismatches. If the destination depends on a field that falls into either case, map and validate it explicitly in code rather than relying on `TransferFields` to catch the gap. Use `SkipFieldsNotMatchingType = true` only when skipping same-extension type mismatches is an intentional, documented part of the transfer contract.
 
+See sample: `transferfields-skip-type-mismatch-can-drop-data.good.al`.
+
 ## Anti Pattern
 
 Using `TransferFields(Source, InitPrimaryKeyFields, true)` as a generic way to make two evolving table schemas transfer without errors, when the destination depends on every required source field being copied. A type change on either table can turn a previously transferred field into a silently skipped one without making the transfer itself fail.
-
-See sample: `transferfields-skip-type-mismatch-can-drop-data.good.al`.
 
 See sample: `transferfields-skip-type-mismatch-can-drop-data.bad.al`.

--- a/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.md
+++ b/community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.md
@@ -1,5 +1,5 @@
 ---
-bc-version: [all]
+bc-version: [16..]
 domain: data-modeling
 keywords: [transferfields, skipfieldsnotmatchingtype, type-mismatch, field-mapping, data-transfer]
 technologies: [al]
@@ -15,7 +15,7 @@ application-area: [all]
 
 ## Best Practice
 
-Use `TransferFields(Source)` when matching field definitions are an expected part of the table design. If source and destination fields intentionally have different types, map those fields explicitly and handle the conversion or validation in code. Use `SkipFieldsNotMatchingType = true` only when skipping incompatible fields is an intentional, documented part of the transfer contract.
+Use `TransferFields(Source)` only when every field the destination requires, including primary key fields, is guaranteed to share a matching field number and type with the source; this form defaults `InitPrimaryKeyFields` to `true`. Fields with no matching field number, and fields whose types differ across extensions, are skipped regardless of `SkipFieldsNotMatchingType` — that parameter only governs same-extension type mismatches. If the destination depends on a field that falls into either case, map and validate it explicitly in code rather than relying on `TransferFields` to catch the gap. Use `SkipFieldsNotMatchingType = true` only when skipping same-extension type mismatches is an intentional, documented part of the transfer contract.
 
 ## Anti Pattern
 


### PR DESCRIPTION
## What

One knowledge rule: don't use `TransferFields(..., SkipFieldsNotMatchingType: true)`
as a blanket way to keep two evolving tables transferring without
errors, when the destination actually depends on every source field
being copied.

## Why this belongs in BCQuality

`TransferFields` only errors on a type mismatch when both tables are
in the same extension - cross-extension mismatches are already
skipped by default, flag or not. That distinction isn't obvious from
the method signature, and it's exactly the kind of thing where an AI
(or a dev in a hurry) reaches for `SkipFieldsNotMatchingType = true`
to make a compile/runtime error go away without noticing a field
silently stopped being copied.

## Files

- `community/knowledge/data-modeling/transferfields-skip-type-mismatch-can-drop-data.md`
- `.good.al` - explicit field-by-field mapping with `Evaluate` for the
  type conversion, so a bad value fails loudly instead of vanishing
- `.bad.al` - two tables in the same app, `TransferFields(Source, true, true)`,
  `Reference` silently dropped because it's `Code[20]` on one side and
  `Integer` on the other

## Verified against

- Record.TransferFields(var Record, Boolean, Boolean) - Microsoft Learn
- Confirmed the same-extension vs. cross-extension error behavior
  independently against community testing before writing the rule

One concern, one file, community layer.