### PR TITLE
knowledge(security): a guarded Text credential seam is legitimate when SecretText cannot flow end to end

### DIFF
--- a/community/knowledge/security/guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.bad.al
+++ b/community/knowledge/security/guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.bad.al
@@ -1,0 +1,18 @@
+interface "Sec Sample Transport Bad"
+{
+    procedure Send(Uri: Text; AuthorizationHeader: Text): Boolean;
+}
+
+codeunit 50541 "Sec Sample Text Seam Bad"
+{
+    var
+        Transport: Interface "Sec Sample Transport Bad";
+
+    // Half conversion: the parameter became SecretText to satisfy the analyzer,
+    // but the seam is still Text, so the value is unwrapped right away.
+    // Unwrap is on-premises only: this does not hold for a cloud-targeted app.
+    procedure Call(Uri: Text; ApiKey: SecretText): Boolean
+    begin
+        exit(Transport.Send(Uri, 'Bearer ' + ApiKey.Unwrap()));
+    end;
+}

--- a/community/knowledge/security/guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.good.al
+++ b/community/knowledge/security/guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.good.al
@@ -1,0 +1,30 @@
+interface "Sec Sample Transport Good"
+{
+    // The seam is Text by design: the test double asserts WHERE the credential travels.
+    procedure Send(Uri: Text; AuthorizationHeader: Text): Boolean;
+}
+
+codeunit 50540 "Sec Sample Text Seam Good"
+{
+    var
+        Transport: Interface "Sec Sample Transport Good";
+
+    [NonDebuggable]
+    procedure Call(Uri: Text; ServiceCode: Code[20]): Boolean
+    var
+        ApiKey: Text;
+    begin
+        // Plain-text path kept as short as possible; value is encrypted at rest.
+#pragma warning disable LC0043 // Text seam: the transport interface and its test double are typed Text on purpose
+        if not IsolatedStorage.Get(ServiceCode, DataScope::Company, ApiKey) then
+            exit(false);
+        exit(Transport.Send(Uri, 'Bearer ' + ApiKey));
+#pragma warning restore LC0043
+    end;
+
+    [NonDebuggable]
+    procedure Store(ServiceCode: Code[20]; ApiKey: Text)
+    begin
+        IsolatedStorage.SetEncrypted(ServiceCode, ApiKey, DataScope::Company);
+    end;
+}

--- a/community/knowledge/security/guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.md
+++ b/community/knowledge/security/guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.md
@@ -1,0 +1,28 @@
+---
+bc-version: [23..]
+domain: security
+keywords: [secrettext, text-seam, interface, nondebuggable, unwrap, lc0043, pragma, half-conversion, test-double]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# A guarded Text credential seam is legitimate when SecretText cannot flow end to end
+
+> Contributions welcome — open a PR to refine or extend this article.
+
+## Description
+
+`SecretText` can only protect a credential along a path where every API accepts it. Some seams are typed `Text` by design: an injectable interface whose test double asserts *where* the credential travels (header versus body), or a legacy consumer that takes `Text`. Retyping such a seam to `SecretText` does not complete the conversion — the value must become `Text` again at the seam, and `SecretText.Unwrap()` is on-premises only (see `nondebuggable-required-when-unwrapping-secrettext.md`). A cloud app therefore cannot convert this path end to end, and a partial conversion is worse than none: it either does not build for the cloud target or destroys the test that pinned the credential's placement. An analyzer such as LinterCop LC0043 flags the `Text` seam; the rule is right in general and wrong at exactly this location.
+
+## Best Practice
+
+When a `Text` seam cannot be removed, keep it `Text` and guard it instead: mark every procedure that touches the plain value `[NonDebuggable]`, keep the plain-text path as short as possible, store the value encrypted at rest (`IsolatedStorage` with `SetEncrypted`), and suppress the analyzer with a `#pragma` scoped to the exact statements, restored immediately, with a comment naming the seam that justifies it. Prefer removing the seam when the callee has a `SecretText`-aware API (`HttpHeaders.Add`, `HttpContent.WriteFrom`, `SetSecretRequestUri` — see `secrettext-with-httpclient.md`); the guarded `Text` seam is the fallback, not the default.
+
+See sample: `guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.good.al`.
+
+## Anti Pattern
+
+A review finding that demands `SecretText` on a guarded `Text` seam without checking whether the value can stay `SecretText` up to the sink. Acting on it produces the half conversion: a `SecretText` parameter that is immediately `Unwrap()`-ed to call the `Text` seam, or a seam retyped to `SecretText` whose test double can no longer assert the credential's placement. Signals to detect the half conversion: `Unwrap()` in a cloud-targeted app, or a `SecretText` parameter converted back to `Text` within the same procedure.
+
+See sample: `guarded-text-credential-seam-is-legitimate-when-secrettext-cannot-flow-end-to-end.bad.al`.


### PR DESCRIPTION
## What

One community knowledge file (security) with good/bad samples: a `Text` credential seam guarded by `[NonDebuggable]`, encryption at rest and a statement-scoped, justified analyzer suppression is **not** a defect when the value cannot stay `SecretText` up to the sink — and the **half conversion** a naive "use SecretText" finding produces is the real defect.

## Admission test

A capable LLM reviewing a `Text` seam (an injectable transport interface whose test double asserts *where* the credential travels, or a legacy `Text`-only consumer) reliably demands `SecretText`. Acting on that produces one of two broken outcomes, both observed in a real cloud app: a `SecretText` parameter immediately `Unwrap()`-ed to call the seam (on-premises only, so not viable for the cloud target), or a seam retyped to `SecretText` whose test double can no longer pin the credential's placement. This file is negative knowledge in the sense of `skills/write.md`: it tells the reviewer what not to flag, why, and gives the detection signal for the half conversion instead.

It complements — does not restate — `nondebuggable-required-when-unwrapping-secrettext.md` (which covers the unavoidable on-premises `Unwrap`) and `secrettext-with-httpclient.md` (the preferred path when the sink is secret-aware); both are cross-referenced.

## Checks

- `validate_frontmatter.py`: 0 errors, 0 warnings. `Test-KnowledgeIndex.ps1`: PASSED (deterministic, full coverage).
- 28 lines, one concern, samples referenced by filename, ids 50540–50541 (unused in the corpus).
- `Test-ReviewFixtures.ps1` could not be run locally (a .NET assembly-load crash that reproduces on the untouched upstream tree — environment, not content); relying on CI for it.