### PR TITLE
knowledge(testing): license-entitlement failures on posted tables in a SaaS test run are environmental

### DIFF
--- a/community/knowledge/testing/license-entitlement-failures-on-posted-tables-are-environmental.bad.al
+++ b/community/knowledge/testing/license-entitlement-failures-on-posted-tables-are-environmental.bad.al
@@ -1,0 +1,25 @@
+codeunit 50543 "Test Sample Posted Fixture Bad"
+{
+    Subtype = Test;
+    TestPermissions = Disabled; // does not help: the check is the license, not the permission set
+
+    // Direct insert into a posted table: green under a container runner,
+    // "Your license does not grant you ... Insert" under a SaaS user license.
+    local procedure CreatePostedPurchaseInvoice(): Code[20]
+    var
+        PurchInvHeader: Record "Purch. Inv. Header";
+    begin
+        PurchInvHeader.Init();
+        PurchInvHeader."No." := 'PI-TEST-001';
+        PurchInvHeader.Insert();
+        exit(PurchInvHeader."No.");
+    end;
+
+    [Test]
+    procedure PostedInvoiceIsAvailable()
+    var
+        PurchInvHeader: Record "Purch. Inv. Header";
+    begin
+        PurchInvHeader.Get(CreatePostedPurchaseInvoice());
+    end;
+}

--- a/community/knowledge/testing/license-entitlement-failures-on-posted-tables-are-environmental.good.al
+++ b/community/knowledge/testing/license-entitlement-failures-on-posted-tables-are-environmental.good.al
@@ -1,0 +1,24 @@
+codeunit 50542 "Test Sample Posted Fixture Good"
+{
+    Subtype = Test;
+
+    var
+        LibraryPurchase: Codeunit "Library - Purchase";
+
+    // Posted data is produced by posting, so the fixture runs under any license.
+    local procedure CreatePostedPurchaseInvoice(): Code[20]
+    var
+        PurchaseHeader: Record "Purchase Header";
+    begin
+        LibraryPurchase.CreatePurchaseInvoice(PurchaseHeader);
+        exit(LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true));
+    end;
+
+    [Test]
+    procedure PostedInvoiceIsAvailable()
+    var
+        PurchInvHeader: Record "Purch. Inv. Header";
+    begin
+        PurchInvHeader.Get(CreatePostedPurchaseInvoice());
+    end;
+}

--- a/community/knowledge/testing/license-entitlement-failures-on-posted-tables-are-environmental.md
+++ b/community/knowledge/testing/license-entitlement-failures-on-posted-tables-are-environmental.md
@@ -1,0 +1,28 @@
+---
+bc-version: [all]
+domain: testing
+keywords: [license, entitlement, posted-tables, ledger, direct-insert, sandbox, saas, test-runner, environmental-failure, triage]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# License-entitlement failures on posted tables in a SaaS test run are environmental
+
+> Contributions welcome — open a PR to refine or extend this article.
+
+## Description
+
+A test session against a SaaS sandbox runs under the signed-in user's **license entitlement**, and entitlements grant only indirect access to posted and ledger tables. A test helper that inserts directly into such a table fails with `Your license does not grant you the following permissions on TableData <table>: Insert`. This is a license check, not a permission-set check: `TestPermissions = Disabled` and `SUPER` do not lift it. The same test is green under a container or pipeline test runner, whose license does not carry the restriction. The failure is therefore environmental — it says where the test ran, not that the change under review broke anything.
+
+## Best Practice
+
+Triage a license-entitlement failure on a posted or ledger table as environment-limited before suspecting the diff: confirm the same test failed identically on the pre-change baseline in the same environment. For a durable fix, create posted data through posting — the test library codeunits (`Library - Sales`, `Library - Purchase`) create and post documents — so the test runs under any license and exercises the posting path it depends on.
+
+See sample: `license-entitlement-failures-on-posted-tables-are-environmental.good.al`.
+
+## Anti Pattern
+
+Reporting the failure as a regression of the change under review, "fixing" it by adding `TestPermissions = Disabled` or a broader permission set (neither is consulted by the license check), or building fixtures by `Init` + direct `Insert` into a posted table, which passes only where the runner's license allows it.
+
+See sample: `license-entitlement-failures-on-posted-tables-are-environmental.bad.al`.


### PR DESCRIPTION
## What

One community knowledge file (testing) with good/bad samples: a test that inserts directly into a posted or ledger table fails under a SaaS user license with `Your license does not grant you the following permissions on TableData <table>: Insert`, while the same test is green under a container / pipeline runner. The failure is **environmental**, and neither `TestPermissions = Disabled` nor `SUPER` lifts it, because it is a license-entitlement check, not a permission-set check.

## Admission test

A capable LLM reading that message in a test log classifies it as a permission regression of the change under review and "fixes" it with `TestPermissions = Disabled` or a broader permission set — neither of which is consulted by the license check. Observed on a real suite run headless against a SaaS sandbox (`al runtests`): the failing codeunits were byte-identical to the pre-change baseline and green in the AL-Go pipeline. The file encodes the triage rule (compare with the baseline in the same environment first) and the durable fix (produce posted data through posting via the test library codeunits, so the fixture runs under any license).

This is the testing-side counterpart of `security/do-not-grant-rights-beyond-a-users-entitlement.md` — that one is about what an app may grant; this one is about how the entitlement shows up in a test run and how to read it.

## Checks

- `validate_frontmatter.py`: 0 errors, 0 warnings. `Test-KnowledgeIndex.ps1`: PASSED.
- 28 lines, one concern, samples referenced by filename, ids 50542–50543 (unused in the corpus). New `community/knowledge/testing/` folder (first community article in that domain).
- `Test-ReviewFixtures.ps1` could not be run locally (a .NET assembly-load crash that reproduces on the untouched upstream tree — environment, not content); relying on CI for it.