### PR TITLE
knowledge: three false-positive guards from BCApps PR 10277, 10278 and 10346

### DIFF
--- a/microsoft/knowledge/appsource/two-level-namespace-replaces-object-affix-not-extension-member-affix.md
+++ b/microsoft/knowledge/appsource/two-level-namespace-replaces-object-affix-not-extension-member-affix.md
@@ -1,7 +1,7 @@
 ---
 bc-version: [23..]
 domain: appsource
-keywords: [namespace, two-level, affix, prefix, suffix, as0011, tableextension, pageextension]
+keywords: [namespace, two-level, affix, prefix, suffix, as0011, tableextension, pageextension, false-positive]
 technologies: [al]
 countries: [w1]
 application-area: [all]
@@ -13,14 +13,16 @@ application-area: [all]
 
 Current AppSource naming guidance accepts a namespace with at least two levels, such as `Contoso.Rentals`, instead of a registered prefix or suffix on the names of objects the app owns. The namespace does not qualify members added to another publisher's object: fields, keys, controls, and actions introduced through table or page extensions still share the target object's flat member namespace and still need the registered affix.
 
+The requirement comes from AppSourceCop rule AS0011, which only runs when the app enables AppSourceCop and configures a mandatory affix — normally an `AppSourceCop.json` next to the app manifest. An app that ships no such configuration is not subject to AS0011, and its extension members are not a compliance gap. This is the usual situation for first-party, in-box apps that ship as part of the product rather than through AppSource: their uniqueness comes from allocated object ID ranges and a controlled source tree, not from a registered affix. Confirm the extending app actually configures a mandatory affix before reporting an unaffixed extension member.
+
 ## Best Practice
 
-Choose one collision strategy for owned objects: a registered affix or a globally meaningful namespace with at least two levels. Regardless of that choice, apply the registered affix to every member added to a base or third-party object. Keep the affix configured for AppSourceCop so member validation remains deterministic.
+Choose one collision strategy for owned objects: a registered affix or a globally meaningful namespace with at least two levels. Regardless of that choice, apply the registered affix to every member added to a base or third-party object. Keep the affix configured for AppSourceCop so member validation remains deterministic. Do not raise a missing member affix against an app that does not enable AppSourceCop with a mandatory affix; there AS0011 never fires, and the app's namespace is not the reason — the absent configuration is.
 
 See sample: `two-level-namespace-replaces-object-affix-not-extension-member-affix.good.al`.
 
 ## Anti Pattern
 
-Using `namespace Contoso;` as though one level satisfied the AppSource alternative, or declaring `namespace Contoso.Rentals;` and then adding an unaffixed `Loyalty Points` field to `Customer`. The namespace distinguishes the extension's own objects; it cannot disambiguate members on Customer.
+Using `namespace Contoso;` as though one level satisfied the AppSource alternative, or declaring `namespace Contoso.Rentals;` and then adding an unaffixed `Loyalty Points` field to `Customer` in an app that does configure a mandatory affix. The namespace distinguishes the extension's own objects; it cannot disambiguate members on Customer. The mirror-image mistake is reporting an unaffixed extension member in an app that enables no mandatory affix at all — AS0011 does not apply there, and the finding is a false positive.
 
 See sample: `two-level-namespace-replaces-object-affix-not-extension-member-affix.bad.al`.

--- a/microsoft/knowledge/data-modeling/insert-only-transfer-may-rely-on-caller-cleanup.md
+++ b/microsoft/knowledge/data-modeling/insert-only-transfer-may-rely-on-caller-cleanup.md
@@ -1,0 +1,24 @@
+---
+bc-version: [all]
+domain: data-modeling
+keywords: [transfer, cleanup, deleteall, onvalidate, caller, stale-rows, false-positive]
+technologies: [al]
+countries: [w1]
+application-area: [all]
+---
+
+# An insert-only transfer routine may rely on cleanup its caller already performed
+
+## Description
+
+A routine that copies rows from a template table into a target table — a `TransferX` procedure filling comment, dimension, or attribute lines from a standard-task or template record — is frequently written as filter-and-insert with no `DeleteAll` of its own. That is not automatically a stale-row or duplicate-primary-key defect. In the common AL shape, the field's `OnValidate` trigger first calls a sibling cleanup procedure that clears the same filtered range, then calls the transfer. By the time `Insert` runs, the target range is guaranteed empty, so the transfer has nothing to clean up and adding a second `DeleteAll` inside it would be redundant.
+
+Deciding whether a missing cleanup is real therefore requires reading the caller, not just the routine in the diff. The relevant question is whether every path that reaches the transfer clears the target range first — not whether the transfer clears it itself.
+
+## Best Practice
+
+Before reporting a transfer or copy routine for missing cleanup, trace its call sites. If the callers in scope invoke a cleanup procedure that clears the same filtered range immediately beforehand — typically in the same `OnValidate` trigger or the same routine — the insert-only transfer is correct and must not be flagged for stale rows, duplicate keys, or a missing `DeleteAll`. Raise the finding only when a reachable call path inserts into a range that was not cleared, or when the cleanup filters a different range than the insert writes to.
+
+## Anti Pattern
+
+Reporting an insert-only transfer as a stale-row or duplicate-key risk on the strength of the routine body alone, when the trigger that calls it already ran the cleanup. The mirror-image mistake is waving through a transfer whose caller clears a *different* filter range than the one the transfer inserts into, or one reachable from a path with no cleanup at all — those are genuine defects.

--- a/microsoft/knowledge/testing/permission-tests-must-lower-the-execution-context.md
+++ b/microsoft/knowledge/testing/permission-tests-must-lower-the-execution-context.md
@@ -1,7 +1,7 @@
 ---
 bc-version: [all]
 domain: testing
-keywords: [testpermissions, restrictive, disabled, permissions-mock, lower-permissions, super, permission-test]
+keywords: [testpermissions, restrictive, disabled, permissions-mock, lower-permissions, super, permission-test, false-positive]
 technologies: [al]
 countries: [w1]
 application-area: [all]
@@ -13,14 +13,16 @@ application-area: [all]
 
 `TestPermissions` describes how a test runner should establish the permission context; the enum value does not itself assign the business permission set being tested. `Restrictive` is the default and starts from D365 Full Access, requiring the test to lower permissions. `Disabled` leaves the test running as `SUPER`. A test that expects access to be denied while still running with either broad context can pass or fail for the wrong reason and never exercise the intended boundary.
 
+What matters is the effective permission context at the moment the protected operation runs, not which permission set object the test names. A test may establish that context through a composed role that includes the permission set under test rather than applying that set directly — that mirrors how the permission set actually reaches a user in production, where roles are assigned and permission sets are included. Such a test is adequate when it proves the boundary it claims: for an indirect (lowercase `imd`) grant, asserting `WritePermission()` is false before invoking the mediating codeunit shows that no direct access was granted and that the subsequent write succeeded only through code.
+
 ## Best Practice
 
-Use `TestPermissions::Restrictive` for a permission-sensitive test and lower the current test user with the test framework's `"Permissions Mock"` or `"Library - Lower Permissions"` before invoking the protected operation. Assign the exact permission set the scenario claims to test and restore or stop the mock afterward. Use `Disabled` only for suites that do not assert permission behavior.
+Use `TestPermissions::Restrictive` for a permission-sensitive test and lower the current test user with the test framework's `"Permissions Mock"` or `"Library - Lower Permissions"` before invoking the protected operation. Assign a permission context that actually contains the rights the scenario tests — either the permission set itself or a role that includes it — and restore or stop the mock afterward. Use `Disabled` only for suites that do not assert permission behavior, or where the test lowers the context explicitly through the test libraries instead of relying on the runner. Do not require a test to apply the permission set under test directly when it reaches the same rights through a composed role and then asserts the boundary.
 
 See sample: `permission-tests-must-lower-the-execution-context.good.al`.
 
 ## Anti Pattern
 
-Setting `TestPermissions = Disabled` or leaving the effective D365 Full Access context in place while asserting that a limited user is denied, or adding a `[TestPermissions(...)]` attribute without any runner/test-library code that applies the intended permission set.
+Setting `TestPermissions = Disabled` or leaving the effective D365 Full Access context in place while asserting that a limited user is denied, or adding a `[TestPermissions(...)]` attribute without any runner/test-library code that applies the intended permission set. Do not report the mirror image: a test that lowers the context through a role including the permission set under test, and then asserts the boundary, has exercised that permission set and is not a coverage gap.
 
 See sample: `permission-tests-must-lower-the-execution-context.bad.al`.


### PR DESCRIPTION
Three false-positive guards adjudicated from self-improvement runs on BCApps PR 10277, 10278 and 10346. Each was verified against the real code before writing; the two edited articles keep their original rule intact and only add the precondition that was missing.

## 1. `data-modeling/insert-only-transfer-may-rely-on-caller-cleanup.md` (new)

**Finding:** a `TransferStandardTaskComments` routine filters the target range and inserts rows without a `DeleteAll` of its own, and was reported as a stale-row / duplicate-primary-key risk across six separate discussions (PR 10278, r3796082947, r3796083192, r3812049359, r3812049579, r3821629898, r3821630138).

**Why it is a false positive:** the field's `OnValidate` trigger calls a sibling `DeleteRelations()` that clears the same filtered range immediately before the transfer runs, so the target range is empty by the time `Insert` executes. The developer replied that "standard already runs DeleteRelations OnValidate() - so the Comments are already deleted". Judging the routine body in isolation cannot reach the right answer; the caller has to be read.

**What the article does:** asks reviewers to trace call sites before reporting a missing cleanup, and keeps the genuine defects reportable — a reachable path with no cleanup, or a cleanup whose filter range differs from the range the transfer inserts into.

No existing article covered this: a corpus search for `DeleteAll`, stale rows, duplicate keys and primary-key violations returned only performance-domain bulk-operation articles and `data-modeling/setup-table-is-a-singleton`, none of which address caller-performed cleanup.

## 2. `appsource/two-level-namespace-replaces-object-affix-not-extension-member-affix.md`

**Finding:** a `tableextension` field added to `Posted Invt. Put-away Line` was reported as missing a registered ISV affix (PR 10277, r3796800252 and r3796803103).

**Why it is a false positive:** the member-affix requirement comes from AppSourceCop rule AS0011, which only runs when the app enables AppSourceCop with a configured mandatory affix. The extending app configures none, so AS0011 never fires.

**Verified, not assumed:** the whole BCApps tree contains exactly two `AppSourceCop.json` files, both under `src/Apps/W1/EDocumentConnectors/ForNAV` (a third-party connector), and neither declares a mandatory affix. The app in question, `src/Apps/W1/Subcontracting`, is `publisher: Microsoft` and ships no AppSourceCop configuration.

**What the change does:** adds the enablement precondition to the Description, Best Practice and Anti Pattern. The member-affix rule itself is unchanged and still applies in full to any app that does configure a mandatory affix.

Note: the reasoning the self-improvement run originally proposed — that a two-level namespace makes the affix unnecessary — is exactly what this article already refutes, and was **not** adopted. The correct ground is the absent AppSourceCop configuration.

## 3. `testing/permission-tests-must-lower-the-execution-context.md`

**Finding:** a test covering an indirect (lowercase `imd`) grant was reported as never lowering permissions to the permission set under test (PR 10346).

**Why it is a false positive:** the test does lower the context — through `Sample Role Basic`, a role whose `IncludedPermissionSets` contains the edit set — then asserts `WritePermission()` is false to prove no direct access was granted, and only then calls the management codeunit and confirms the record was written indirectly. The article's wording, "Assign the exact permission set the scenario claims to test", made the composed-role form look non-compliant.

**What the change does:** states that what matters is the effective permission context plus a boundary assertion, not which permission set object the test names by. Also widens the `Disabled` guidance, which previously read as an unconditional prohibition for permission-sensitive suites: in BCApps, 70 of the 85 test files that use `"Permissions Mock"` carry no `TestPermissions` attribute at all and only 3 use `Restrictive`, so lowering the context explicitly through the test libraries is the prevailing pattern, not a defect. The original anti pattern — asserting denial while still effectively running as `SUPER`, or attributing a test with no library code that applies the permission set — is unchanged.

## Verification

- New article validated by regenerating the index with `tools/Build-KnowledgeIndex.ps1`: 273 articles parsed, the new slug present. `knowledge-index.json` is untracked and not committed.
- All six required frontmatter fields present on the new article; `false-positive` keyword added to all three.
- No fenced code blocks in any changed `.md` (verified by count).
- `git diff --check` clean; 3 files changed, 34 insertions, 6 deletions.
- Following repo convention for false-positive articles, no sibling `.al` samples are added — of the 19 articles currently carrying the `false-positive` keyword, 17 ship no samples.

## Scope

Adjudicated from the same batch, deliberately **not** included here:

- The additive-event-parameter and subscriber-parameter-subset guards are handled in #139 and #138.
- A proposed guard for `security/commitbehavior-attribute-scopes-explicit-commits` was rejected: its argument was that neighbouring events carry no `[CommitBehavior]`, which is an appeal to local precedent rather than a technical one, and by the article's own test the event in question fires after the line has been inserted.
- A proposed guard for `privacy/table-level-data-classification-cascades` was rejected as already covered; that article states the rule and carries the `false-positive` keyword today.
