### PR TITLE
knowledge: improve review precision from BCApps PR 10252 feedback

### DIFF
--- a/microsoft/knowledge/upgrade/use-upgrade-tags-not-version-checks.md
+++ b/microsoft/knowledge/upgrade/use-upgrade-tags-not-version-checks.md
@@ -1,7 +1,7 @@
 ---
 bc-version: [all]
 domain: upgrade
-keywords: [upgrade-tag, version-check, dataversion, has-upgrade-tag, set-upgrade-tag, control-flow]
+keywords: [upgrade-tag, version-check, dataversion, has-upgrade-tag, set-upgrade-tag, control-flow, dynamic-check, runtime-function, always-log-table, non-persisted-state]
 technologies: [al]
 countries: [w1]
 application-area: [all]
@@ -12,6 +12,10 @@ application-area: [all]
 ## Description
 
 Each piece of upgrade logic must run exactly once per company (or database) across the lifetime of an extension. The platform mechanism for that is the `Upgrade Tag` codeunit: a procedure asks `HasUpgradeTag(MyTag())` at entry, performs its work, then calls `SetUpgradeTag(MyTag())` to record completion. Subsequent upgrades on the same tenant see the tag and skip the work. Hand-rolled `if MyApp.DataVersion().Major < N then ...` chains are the wrong tool: they are version-coupled, accumulate stale branches over time, and break when a tenant skips a version.
+
+## Scope
+
+Upgrade tags guard one-time work that mutates persisted, per-company state (data, setup records, or a stored schema baseline) so it runs exactly once. They do not apply to a hard-coded list or condition inside an ordinary runtime function that is evaluated fresh on every call and never persists its result — for example, a function that decides live whether a given table is in the "always log changes" set for the change-log feature. Adding or removing an entry from such a list is a normal behavior change: it only affects future evaluations of the function, there is no stored per-company flag or record whose absence would leave old data stranded, so no upgrade tag, upgrade codeunit, or migration step is needed.
 
 ## Best Practice
 


### PR DESCRIPTION
## Summary

Improves BCQuality knowledge based on maintainer thumbs-down feedback from explicit BCApps PR review runs.

## Source feedback

- https://github.com/microsoft/BCApps/pull/10252#discussion_r3873927635

## Validation

- Frontmatter and article structure validation completed.

Generated by the BC-ALAgentsInternal self-improvement workflow.

<!-- self-improvement-gate:start -->
## Offline evaluation: inconclusive

No knowledge change or no baseline false-positive reproduction. This pair cannot establish target suppression.

Preparation attempt 1: invalid_selection. Coverage requires a patched file and valid lineStart/lineEnd for synthetic__upgrade-alwayslogtable-removal-01.

Preparation attempt 2: validated. 

Selection: **new**. New: `synthetic__upgrade-alwayslogtable-removal-01`. Reused (complete payloads): ``.

- `synthetic__upgrade-alwayslogtable-removal-01` / `false_positive_guard` / https://github.com/microsoft/BCApps/pull/10252#discussion_r3873927635: The review bot flagged removal of four table IDs from the OnAfterIsAlwaysLoggedTable allow-list as needing an upgrade tag, and the maintainer rejected this with a THUMBS_DOWN, replying that these are dynamic checks and do not require upgrade. Confirmed against Change Log Management's IsAlwaysLoggedTable: it recomputes the always-logged decision on every insert/modify/delete/rename call and never persists an AlwaysLogTable flag or setup record, so trimming this hard-coded in-code list changes only future auditing decisions, not stored per-company data or schema, and needs no migration or upgrade tag. expected_comments is intentionally empty so no upgrade-migration finding is required in this table-ID range; this is a false-positive guard by omission, not a proof that every possible finding on this hunk is wrong, and it does not assert any severity or recommendation repair beyond the specific upgrade-tag claim that was rejected.
Coverage references and outcome shapes are validated mechanically. Semantic equivalence, severity calibration and recommendation quality are NOT proved by these checks or a matching F1.

Common engine code: `ecf8e31759d6ddd6d78e3a0b7836b40134368009`; dataset SHA256: `40F87789093B7D383AE8F4406D8057AC4F15DFD7E86D72D1D3AE9FF599F1692E`.
Model: `gpt-5.6-luna`; judge: `gpt-5.3-codex`. Exact D: `synthetic__upgrade-alwayslogtable-removal-01`.
Dataset base: `26365d6a41a96fac41df9dcc8339cb71241fcb1f`; candidate: `66098eaf621dcf9a6f3508a2cbe0f7dbe5e06f19`.

| Arm | Evaluation commit | Engine pin | Knowledge pin |
| --- | --- | --- | --- |
| baseline | `fa74a78af16283d5bc40f8ff94a703a4cd08e8af` | `4407f20b44fe92e3693d0444d25cc3430f1d5262` | `8584217c7506eea7eef27a9db353d78c0cd6a9a1` |
| candidate | `57f097a467b133191a2babb7c6b09f061ad701ab` | `ea0104e6ad2c21173b774ba627852f8c0b65b515` | `e7ee9b4b5af18f344f5ca45eebeaf92ac578dd69` |

### Baseline
Run: https://github.com/microsoft/BC-Bench/actions/runs/34341668876; conclusion: success; wall clock: 6.4 minutes.
Raw findings and runtime pin proofs are retained in the self-improvement-feedback artifact and the linked evaluation run.

| Entry | Expected | Generated | Missed | Unexpected | F1 | AI credits | Agent seconds |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `synthetic__upgrade-alwayslogtable-removal-01` | 0 | 0 | 0 | 0 | 1 | unavailable | 163.777077015 |

Observed AI credits: unavailable; coverage 0/1 entries. Missing entries are not extrapolated into a total.

| Aggregate metric | Value |
| --- | --- |
| total | 1 |
| expected_comment_count | 0 |
| generated_comment_count | 0 |
| matched_comment_count | 0 |
| missed_comment_count | 0 |
| incorrect_comment_count | 0 |
| precision | 1 |
| recall | 1 |
| f1 | 1 |

### Candidate
Run: https://github.com/microsoft/BC-Bench/actions/runs/34342284452; conclusion: success; wall clock: 7.4 minutes.
Raw findings and runtime pin proofs are retained in the self-improvement-feedback artifact and the linked evaluation run.

| Entry | Expected | Generated | Missed | Unexpected | F1 | AI credits | Agent seconds |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `synthetic__upgrade-alwayslogtable-removal-01` | 0 | 0 | 0 | 0 | 1 | unavailable | 195.732926681 |

Observed AI credits: unavailable; coverage 0/1 entries. Missing entries are not extrapolated into a total.

| Aggregate metric | Value |
| --- | --- |
| total | 1 |
| expected_comment_count | 0 |
| generated_comment_count | 0 |
| matched_comment_count | 0 |
| missed_comment_count | 0 |
| incorrect_comment_count | 0 |
| precision | 1 |
| recall | 1 |
| f1 | 1 |

Missing telemetry is unavailable, not zero. Evaluation-only metrics exclude candidate generation and are not the full-cycle cost.
Human review must verify source-patch fidelity, gold correctness, and target attribution. No automatic merge or branch-protection claim is made.
<!-- self-improvement-gate:data {"version":2,"baseCommit":"8584217c7506eea7eef27a9db353d78c0cd6a9a1","requestId":"","selectedCommentIds":[3873927635],"ownsReadiness":true,"readinessEvent":null,"sourceCommentUrls":["https://github.com/microsoft/BCApps/pull/10252#discussion_r3873927635"],"evaluationSet":{"entryIds":["synthetic__upgrade-alwayslogtable-removal-01"],"version":1,"datasetBase":"26365d6a41a96fac41df9dcc8339cb71241fcb1f","datasetHash":"40F87789093B7D383AE8F4406D8057AC4F15DFD7E86D72D1D3AE9FF599F1692E","mode":"new","manifestHash":"4EA2A5F29FECC46BA3706911A29E6908A8DF8FE4AF11C1E27F04FF316BAD6263","newEntryIds":["synthetic__upgrade-alwayslogtable-removal-01"],"reusedEntryIds":[],"manifestCommit":"66098eaf621dcf9a6f3508a2cbe0f7dbe5e06f19","sourceCommentUrls":["https://github.com/microsoft/BCApps/pull/10252#discussion_r3873927635"]},"selectionQualityHead":"e7ee9b4b5af18f344f5ca45eebeaf92ac578dd69"} -->
<!-- self-improvement-gate:end -->

