### PR TITLE
Frame app review as one standalone plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ A file that *prevents* a false positive — documenting why a pattern is legitim
 
 ## What's in this repo
 
-BCQuality contains **knowledge** and **skills**. It does not contain agents. Agents that consume BCQuality ship with [AL-Go](https://github.com/microsoft/AL-Go) and other orchestrators.
+BCQuality contains **knowledge** and **skills**. It does not contain agents.
+Agents that consume BCQuality are supplied by the host or orchestrator.
 
 ### Knowledge files
 
@@ -60,13 +61,17 @@ Skills define how agents consume knowledge. They come in three flavors:
 
 ### Agent bootstrapping
 
-An orchestrator (such as AL-Go) points the agent at BCQuality's URL and provides a task context. The agent's first call is `/skills/entry.md`, which returns a dispatch record naming the action skill(s) to invoke. The agent then invokes the dispatched skills, reading READ and DO on demand. No prior knowledge of BCQuality's structure is baked into the orchestrator — only the convention *"invoke `/skills/entry.md` first."*
+A host or orchestrator points the agent at BCQuality and provides a task
+context. The agent's first call is `/skills/entry.md`, which returns a dispatch
+record naming the action skill(s) to invoke. The agent then invokes the
+dispatched skills, reading READ and DO on demand. No prior knowledge of
+BCQuality's structure is required beyond the convention *"invoke
+`/skills/entry.md` first."*
 
 ### Standalone plugin installation
 
-BCQuality can also be installed directly as a plugin to review a complete AL
-app folder, a change set, or an individual file. The plugin registers one
-host-native skill,
+BCQuality can also be installed directly as a plugin so supported hosts can
+discover and invoke its host-native skills. The plugin currently registers
 [`al-code-review`](skills/al-code-review/SKILL.md), which adapts the caller's
 request to the same Entry protocol used by orchestrators.
 
@@ -76,7 +81,11 @@ For GitHub Copilot CLI:
 copilot plugin install microsoft/BCQuality
 ```
 
-#### Review a complete app folder
+#### Example: Review a complete app folder
+
+This example demonstrates the walk-up pattern with the currently exposed
+review skill. Future host-native skills follow the same discovery and
+invocation pattern; they do not each require a dedicated README walkthrough.
 
 1. Open the Business Central app folder in GitHub Copilot and start a fresh
    session after installing the plugin.
@@ -93,12 +102,6 @@ a newer BCQuality release later, run:
 ```shell
 copilot plugin update bcquality
 ```
-
-Plugin version `0.2.0` renamed the former `bcquality-al-review` skill to
-`al-code-review`; explicit invocations and allowlists using the old skill name
-must be updated. The name remains distinct from BC-ALAgents' public
-`al-review` skill because current hosts may load plugin skill names into one
-shared inventory.
 
 The adapter is intentionally not a second review implementation:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,6 @@
 - [How agents consume BCQuality](agent-consumption.md) explains the operational
   flow from Entry dispatch through structured findings and integration.
 - [Build a lightweight standalone review runner](standalone-runner.md) explains
-  the walk-up app-folder flow and how an external runner can add model
+  one concrete walk-up skill flow and how an external runner can add model
   selection, concurrency, retries, and telemetry without moving orchestration
   into BCQuality.

--- a/docs/agent-consumption.md
+++ b/docs/agent-consumption.md
@@ -1,13 +1,16 @@
 # How agents consume BCQuality
 
-BCQuality is content — knowledge files and skills. It is consumed by agents that live elsewhere (AL-Go, a VS Code extension, a GitHub Agent invocation, etc.). This document explains the end-to-end flow, so that skill authors, orchestrator maintainers, and contributors share one mental model.
+BCQuality is content — knowledge files and skills. It is consumed by agents
+supplied by a host or orchestrator. This document explains the end-to-end flow
+so that skill authors, orchestrator maintainers, and contributors share one
+mental model.
 
 For the high-level framing and repo structure, start with the
 [README](../README.md). This document is the operational view.
 
 ## The actors
 
-- **Orchestrator** — the tool that triggers work (e.g. AL-Go on a pull request, or a VS Code extension on save). Lives *outside* BCQuality. Knows *when* to run something, not *what* to run.
+- **Orchestrator** — the tool that triggers work. Lives *outside* BCQuality. Knows *when* to run something, not *what* to run.
 - **Agent** — an LLM-driven process spawned by the orchestrator. The agent has no built-in knowledge of BC or of BCQuality's conventions. It knows how to read instructions and call tools.
 - **BCQuality repo** — two kinds of content:
   - **Global skills** in `/skills/` — the `entry.md` entry-point skill plus the READ · DO · WRITE contracts that govern the rest of the repo.
@@ -21,7 +24,7 @@ action skill: it creates the task context and enters the same flow at Entry.
 
 ```mermaid
 flowchart LR
-    O[Orchestrator<br/>AL-Go] -->|1 trigger + task context| A[Agent]
+    O[Host or orchestrator] -->|1 trigger + task context| A[Agent]
     A -->|2 invoke entry.md| E[Entry<br/>routing skill]
     E -->|3 dispatch record| A
     A -->|4 invoke dispatched skill| S[Action skill<br/>e.g. al-code-review]

--- a/docs/standalone-runner.md
+++ b/docs/standalone-runner.md
@@ -97,7 +97,6 @@ A compatible runner:
 - preserves knowledge paths verbatim and verifies references before publishing;
 - records the BCQuality commit or release used for the run.
 
-BC-ALAgents, AL-Go, a Copilot custom agent, or a small host-native plugin can
-all implement this runner contract. They remain optional consumers:
-BCQuality's knowledge and skills stay independent of their orchestration
-choices.
+A CI integration, custom agent, or small host-native plugin can implement this
+runner contract. These remain optional consumers: BCQuality's knowledge and
+skills stay independent of their orchestration choices.

--- a/skills/README.md
+++ b/skills/README.md
@@ -48,8 +48,6 @@ This gives the two skill formats distinct roles:
 The host adapter and internal coordinator deliberately share the
 `al-code-review` name because they represent the same user-facing operation in
 their respective formats. Their locations distinguish their roles. The
-adapter remains distinct from BC-ALAgents' separately installed `al-review`
-skill, avoiding a collision in hosts that use one shared skill inventory. The
 reference from the adapter to Entry, and from a dispatched super-skill to its
 leaf skills, is intentional progressive disclosure. It avoids registering
 every internal BCQuality protocol file as an ambient host skill while allowing


### PR DESCRIPTION
The standalone documentation should explain BCQuality's general skill model without making the project appear code-review-only or requiring readers to understand naming history and external implementations.

## Changes

- Present standalone installation as discovery and invocation of host-native BCQuality skills.
- Label complete app review as one concrete example of the walk-up pattern.
- Clarify that future skills follow the same discovery pattern rather than each needing a README walkthrough.
- Remove historical skill naming and references to external orchestrators from the README, architecture guide, runner guide, and skills documentation.

This keeps the documentation focused on BCQuality's own concepts and current behavior.